### PR TITLE
[REF] use Table attributes insted of DataHintsCache

### DIFF
--- a/orangecontrib/bioinformatics/widgets/OWGEODatasets.py
+++ b/orangecontrib/bioinformatics/widgets/OWGEODatasets.py
@@ -22,7 +22,6 @@ from Orange.widgets import gui
 from Orange.widgets.widget import OWWidget
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.concurrent import ThreadExecutor, Task, methodinvoke
-from Orange.widgets.utils.datacaching import data_hints
 
 from orangecontrib.bioinformatics.utils import serverfiles
 from orangecontrib.bioinformatics.geo.utils import gds_ensure_downloaded
@@ -576,8 +575,8 @@ class OWGEODatasets(OWWidget):
         if message is not None:
             self.warning(0, message)
 
-        data_hints.set_hint(data, TAX_ID, self.currentGds.get("taxid", ""))
-        data_hints.set_hint(data, GENE_AS_ATTRIBUTE_NAME, bool(self.outputRows))
+        data.attributes[TAX_ID] = self.currentGds.get('taxid', '')
+        data.attributes[GENE_AS_ATTRIBUTE_NAME] = bool(self.outputRows)
 
         data.name = data_name
         self.send("Expression Data", data)

--- a/orangecontrib/bioinformatics/widgets/OWGOBrowser.py
+++ b/orangecontrib/bioinformatics/widgets/OWGOBrowser.py
@@ -10,7 +10,6 @@ import Orange.data
 import logging
 
 
-from requests.exceptions import ConnectTimeout
 from collections import defaultdict
 from functools import reduce
 from concurrent.futures import Future
@@ -32,7 +31,6 @@ from Orange.widgets.utils.concurrent import (
 )
 from Orange.widgets.utils.concurrent import Task
 from Orange.widgets import widget, gui, settings
-from Orange.widgets.utils.datacaching import data_hints
 from orangecontrib.bioinformatics import go
 from orangecontrib.bioinformatics.ncbi import taxonomy
 from orangecontrib.bioinformatics.utils import serverfiles, statistics
@@ -391,7 +389,8 @@ class OWGOBrowser(widget.OWWidget):
             for var in self.candidateGeneAttrs:
                 self.geneAttrIndexCombo.addItem(*gui.attributeItem(var))
 
-            tax_id = data_hints.get_hint(data, TAX_ID, '')
+            tax_id = str(data.attributes.get(TAX_ID, ''))
+
             if tax_id is not None:
                 _c2i = {a.taxid: i for i, a in enumerate(self.availableAnnotations)}
                 try:
@@ -399,7 +398,7 @@ class OWGOBrowser(widget.OWWidget):
                 except KeyError:
                     pass
 
-            self.useAttrNames = data_hints.get_hint(data, GENE_AS_ATTRIBUTE_NAME, default=self.useAttrNames)
+            self.useAttrNames = data.attributes.get(GENE_AS_ATTRIBUTE_NAME, self.useAttrNames)
 
             self.geneAttrIndex = min(self.geneAttrIndex, len(self.candidateGeneAttrs) - 1)
             if len(self.candidateGeneAttrs) == 0:

--- a/orangecontrib/bioinformatics/widgets/OWGeneInfo.py
+++ b/orangecontrib/bioinformatics/widgets/OWGeneInfo.py
@@ -15,7 +15,6 @@ from AnyQt.QtCore import (
     QModelIndex, QItemSelection, QItemSelectionModel, Slot
 )
 
-from Orange.widgets.utils.datacaching import data_hints
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.concurrent import ThreadExecutor, Task, methodinvoke
 from Orange.widgets.utils.signals import Output, Input
@@ -304,8 +303,9 @@ class OWGeneInfo(widget.OWWidget):
             for var in self.attributes:
                 self.geneAttrComboBox.addItem(*gui.attributeItem(var))
 
-            self.taxid = str(data_hints.get_hint(self.data, TAX_ID))
-            self.useAttr = data_hints.get_hint(self.data, GENE_AS_ATTRIBUTE_NAME, default=self.useAttr)
+            self.taxid = str(self.data.attributes.get(TAX_ID, ''))
+            self.useAttr = self.data.attributes.get(GENE_AS_ATTRIBUTE_NAME, self.useAttr)
+
             self.gene_attr = min(self.gene_attr, len(self.attributes) - 1)
 
             if self.taxid in self.organisms:

--- a/orangecontrib/bioinformatics/widgets/OWdictyExpress.py
+++ b/orangecontrib/bioinformatics/widgets/OWdictyExpress.py
@@ -15,7 +15,7 @@ from Orange.data import Table
 from Orange.widgets import gui, settings
 from Orange.widgets.widget import OWWidget, Msg
 from Orange.widgets.utils.signals import Output
-from Orange.widgets.utils.datacaching import data_hints
+# from Orange.widgets.utils.datacaching import data_hints
 
 from orangecontrib.bioinformatics import resolwe
 from orangecontrib.bioinformatics.utils import environ
@@ -244,8 +244,10 @@ class OWdictyExpress(OWWidget):
         self.setStatusMessage('')
 
         data = etc_to_table(etc_json, self.setTimeVariable)
-        data_hints.set_hint(data, TAX_ID, self.orgnism)
-        data_hints.set_hint(data, GENE_AS_ATTRIBUTE_NAME, self.setTimeVariable)
+
+        data.attributes[TAX_ID] = self.orgnism
+        data.attributes[GENE_AS_ATTRIBUTE_NAME] = self.setTimeVariable
+
         self.Outputs.etc_data.send(data)
 
     def commit(self):

--- a/server_update/updateGeneMatcher.py
+++ b/server_update/updateGeneMatcher.py
@@ -68,7 +68,8 @@ for taxonomy_id in common_taxids():
 
     with open(os.path.join(domain_path, MATCHER_FILENAME.format(taxonomy_id)), 'wb') as file:
         pickle.dump(gene_mapper, file, protocol=pickle.HIGHEST_PROTOCOL)
-        uncompressed_size = os.stat(os.path.join(domain_path, MATCHER_FILENAME.format(taxonomy_id))).st_size
+
+    uncompressed_size = os.stat(os.path.join(domain_path, MATCHER_FILENAME.format(taxonomy_id))).st_size
 
     with bz2.BZ2File(os.path.join(temp_path, MATCHER_FILENAME.format(taxonomy_id)), mode='w', compresslevel=9) as f:
         shutil.copyfileobj(open(os.path.join(domain_path, MATCHER_FILENAME.format(taxonomy_id)), "rb"), f)
@@ -81,6 +82,7 @@ for taxonomy_id in common_taxids():
                      tags=MATCHER_TAGS + [taxonomy_id],
                      uncompressed=uncompressed_size,
                      compression='bz2')
+
 
 con.close()
 


### PR DESCRIPTION
##### Issue
DataHintsCache is used for storing information on gene names location and organism.

##### Description of changes
A simpler solution is to use attributes in Orange.data.Table

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
