### PR TITLE
[FIX] gui: always read attribute value as string

### DIFF
--- a/orangecontrib/bioinformatics/widgets/utils/gui/label_selection.py
+++ b/orangecontrib/bioinformatics/widgets/utils/gui/label_selection.py
@@ -107,7 +107,7 @@ def group_candidates(data):
 
     targets = defaultdict(set)
     for label, value in items:
-        targets[label].add(value)
+        targets[label].add(str(value))
 
     # Need at least 2 distinct values or key
     targets = [(key, sorted(vals)) for key, vals in targets.items() if len(vals) >= 2]


### PR DESCRIPTION
##### Issue
OWDifferentialExpression crashes if the variable attribute is not a string.


##### Description of changes
When grouping column candidates, read attribute value as a string.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
