### PR TITLE
[ENH] Assume annotated tables when loading data in widgets

### DIFF
--- a/orangecontrib/bioinformatics/geneset/utils.py
+++ b/orangecontrib/bioinformatics/geneset/utils.py
@@ -183,7 +183,7 @@ class GeneSets(set):
                 columns = [column.strip() for column in line.split('\t')]
                 gs_info = columns[1].split(',')
                 hierarchy = tuple(gs_info[index['hierarchy']].split('-'))
-                genes = set([int(gene) for gene in columns[2:]])
+                genes = set([str(gene) for gene in columns[2:]])
 
                 gene_set = GeneSet(gs_id=columns[0],
                                    genes=genes,

--- a/orangecontrib/bioinformatics/widgets/utils/data.py
+++ b/orangecontrib/bioinformatics/widgets/utils/data.py
@@ -6,6 +6,8 @@ import Orange.data
 from operator import itemgetter
 from typing import Sequence, Tuple
 
+from Orange.widgets.widget import OWWidget, Msg
+
 # Data hints variables
 
 # species
@@ -21,6 +23,10 @@ GENE_ID_COLUMN = 'gene_id_column'
 # Name of the variable attribute that holds gene id
 GENE_ID_ATTRIBUTE = 'gene_id_attribute'
 
+# Error strings
+ERROR_ON_MISSING_ANNOTATION = 'Missing annotation on gene IDs and organism in the input data.'
+ERROR_ON_MISSING_GENE_ID = 'Missing Gene ID information in the input data'
+ERROR_ON_MISSING_TAX_ID = 'Missing organism information in the input data'
 
 col_spec = Sequence[Tuple[Orange.data.Variable, Sequence[numbers.Real]]]
 metas_spec = Sequence[Tuple[Orange.data.Variable, Sequence[str]]]

--- a/orangecontrib/bioinformatics/widgets/utils/settings.py
+++ b/orangecontrib/bioinformatics/widgets/utils/settings.py
@@ -60,4 +60,4 @@ class OrganismContextHandler(settings.ContextHandler):
             return
 
         # get taxonomy id from the widget
-        context.organism = widget.get_selected_organism()
+        context.organism = widget.tax_id


### PR DESCRIPTION
##### TO-DO (merge when done!)
- [X] OWGeneSets: fixes #58 
- [X] OWKEGGPathwayBrowser: fixes #57 
- [X] OWGOBrowser: fixes #56 and fixes #44 

##### Description of changes
Remove Gene name matching process from widgets. All gene name matching will go trough GeneNameMatcher widget.

Remove organism and gene name selection from widget control area.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
