### PR TITLE
 SetContextHandler.settings_to_widget: Add argument *args

### DIFF
--- a/orangecontrib/bioinformatics/widgets/utils/settings.py
+++ b/orangecontrib/bioinformatics/widgets/utils/settings.py
@@ -23,8 +23,8 @@ class SetContextHandler(settings.ContextHandler):
         ctx.items = frozenset(items)
         return ctx
 
-    def settings_to_widget(self, widget):
-        super().settings_to_widget(widget)
+    def settings_to_widget(self, widget, *args):
+        super().settings_to_widget(widget, *args)
 
         context = widget.current_context
         if context is None:


### PR DESCRIPTION
##### Issue

Fixes #120.

If this is not accepted before https://github.com/biolab/orange3/pull/3697, add-on will stop working.

Accepting it before the new release of Orange should not cause any problems.

##### Includes
- [X] Code changes