### PR TITLE
Lock PyQt version for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 install:
     - pip install -U pip wheel coverage codecov
-    - pip install PyQt5
+    - pip install PyQt5==5.11.3
     - pip install -e .
     - pip freeze
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Travis tests fails due to qt issues.

##### Description of changes
PyQt locked to version 5.11.3

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
