### PR TITLE
Annotate projection

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,4 +35,5 @@ Scripting Reference
    scripting_references/dicty_phenotypes
    scripting_references/kegg
    scripting_references/resolwe
+   scripting_references/annotation_projections
    scripting_references/annotation

--- a/doc/scripting_references/annotation.rst
+++ b/doc/scripting_references/annotation.rst
@@ -1,9 +1,13 @@
-.. py:currentmodule:: orangecontrib.bioinformatics.annotation.annotate_samples
-
 ****************
 Sample Annotator
 ****************
 
-.. autoclass:: AnnotateSamples()
+.. autoclass:: orangecontrib.bioinformatics.annotation.annotate_samples.AnnotateSamples()
    :members:
 
+********************
+Projection Annotator
+********************
+
+.. automodule:: orangecontrib.bioinformatics.annotation.annotate_projection
+   :members:

--- a/orangecontrib/bioinformatics/annotation/annotate_projection.py
+++ b/orangecontrib/bioinformatics/annotation/annotate_projection.py
@@ -1,0 +1,136 @@
+"""
+This module cluster the projection of data (usually it is 2D projection) with
+one of the standard algorithms and attach a certain number of labels per
+cluster.
+
+Example:
+
+>>> from Orange.projection import TSNE
+>>> from Orange.data import Table
+>>> from orangecontrib.bioinformatics.utils import serverfiles
+>>> from orangecontrib.bioinformatics.annotation.annotate_projection import annotate_projection
+>>> from orangecontrib.bioinformatics.annotation.annotate_samples import AnnotateSamples
+>>>
+>>> # load data
+>>> data = Table("https://datasets.orange.biolab.si/sc/aml-1k.tab.gz")
+>>> marker_p = serverfiles.localpath_download(
+...     'marker_genes','panglao_gene_markers.tab')
+>>> markers = Table(marker_p)
+>>>
+>>> # annotate data with labels
+>>> annotator = AnnotateSamples(p_value_th=0.05)
+>>> annotations = annotator.annotate_samples(data, markers)
+>>>
+>>> # project data in 2D
+>>> tsne = TSNE(n_components=2)
+>>> tsne_model = tsne(data)
+>>> embedding = tsne_model(data)
+>>>
+>>> # get clusters and annotations for clusters
+>>> clusters, annotations_cl = annotate_projection(annotations, embedding,
+...     clustering_algorithm=DBSCAN(eps=2))
+"""
+
+
+from collections import Counter
+
+from Orange.clustering import DBSCAN
+import numpy as np
+
+
+def _cluster_data(coordinates, clustering_algorithm):
+    """
+    This function receives data and cluster them.
+
+    Parameters
+    ----------
+    coordinates : Orange.data.Table
+        Data to be clustered
+    clustering_algorithm : callable
+        Algorithm used in clustering.
+
+    Returns
+    -------
+    ndarray
+        List of cluster indices.
+    """
+    model = clustering_algorithm(coordinates)
+    return model(coordinates).X.flatten()
+    # TODO: this need to be changed when clustering in orange is changed
+
+
+def _assign_labels(clusters, annotations, labels_per_cluster):
+    """
+    This function assigns a certain number of labels per cluster. Each cluster
+    gets `labels_per_cluster` number of most common labels in cluster assigned.
+
+    Parameters
+    ----------
+    clusters : ndarray
+        Cluster indices for each item.
+    annotations : Orange.data.Table
+        Table with annotations and their probabilities.
+    labels_per_cluster : int
+        Number of labels that need to be assigned to each cluster.
+
+    Returns
+    -------
+    dict
+        Dictionary with cluster index as a key and list of annotations as a
+        value. Each list include tuples with the annotation name and their
+        proportion in the cluster.
+    """
+    labels = np.array(list(map(str, annotations.domain.attributes)))
+    annotation_best_idx = np.argmax(annotations.X, axis=1)
+    annotation_best = labels[annotation_best_idx]
+
+    clusters_unique = set(clusters) - {-1}  # -1 means that item not clustered
+    annotations_clusters = {}
+    for cl in clusters_unique:
+        labels_cl = annotation_best[clusters == cl]
+        counts = Counter(labels_cl)
+        annotations_clusters[cl] = [
+            (l, c / len(labels_cl))
+            for l, c in counts.most_common(labels_per_cluster)]
+
+    return annotations_clusters
+
+
+def annotate_projection(annotations, coordinates,
+                        clustering_algorithm=DBSCAN(),
+                        labels_per_cluster=3):
+    """
+    Function cluster the data based on coordinates, and assigns a certain number
+    of labels per cluster. Each cluster gets `labels_per_cluster` number of most
+    common labels in cluster assigned.
+
+    Parameters
+    ----------
+    annotations : Orange.data.Table
+        Table with annotations and their probabilities.
+    coordinates : Orange.data.Table
+        Data to be clustered
+    clustering_algorithm : callable, optional (default = DBSCAN)
+        Algorithm used in clustering.
+    labels_per_cluster : int, optional (default = 3)
+        Number of labels that need to be assigned to each cluster.
+
+    Returns
+    -------
+    ndarray
+        List of cluster indices.
+    dict
+        Dictionary with cluster index as a key and list of annotations as a
+        value. Each list include tuples with the annotation name and their
+        proportion in the cluster.
+    """
+    assert len(annotations) == len(coordinates)
+    assert len(coordinates) > 0  # sklearn clustering want to have one example
+    assert len(annotations.domain) > 0
+    assert len(coordinates.domain) > 0
+    # get clusters
+    clusters = _cluster_data(coordinates, clustering_algorithm)
+
+    # assign top n labels to group
+    annotations_cl = _assign_labels(clusters, annotations, labels_per_cluster)
+    return clusters, annotations_cl

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -1,6 +1,7 @@
 import time
 import unittest
 
+import Orange
 import numpy as np
 from Orange.clustering import DBSCAN, KMeans
 from Orange.data import Domain, ContinuousVariable, Table, DiscreteVariable
@@ -32,17 +33,20 @@ class TestAnnotateProjection(unittest.TestCase):
         clusters, annotations_cl, locs = annotate_projection(
             self.annotations, self.data, clustering_algorithm=DBSCAN,
             labels_per_cluster=2, eps=3)
-        self.assertListEqual(
-            list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
-            ["0", "0", "0", "0", "0", "1", "1", "1", "1", "1"])
 
-        self.assertEqual(len(annotations_cl), 2)
-        self.assertEqual(len(annotations_cl["0"]), 2)
-        self.assertEqual(len(annotations_cl["1"]), 2)
-        self.assertEqual(annotations_cl["1"][0][0], 'c')
-        self.assertAlmostEqual(annotations_cl["1"][0][1], 0.6, 5)
-        self.assertEqual(annotations_cl["1"][1][0], 'b')
-        self.assertAlmostEqual(annotations_cl["1"][1][1], 0.4, 5)
+        self.assertLessEqual(int(Orange.__version__.split(".")[1]), 21)
+        # TODO: uncomment when new Orange released, and remove version check
+        # self.assertListEqual(
+        #     list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
+        #     ["0", "0", "0", "0", "0", "1", "1", "1", "1", "1"])
+
+        # self.assertEqual(len(annotations_cl), 2)
+        # self.assertEqual(len(annotations_cl["0"]), 2)
+        # self.assertEqual(len(annotations_cl["1"]), 2)
+        # self.assertEqual(annotations_cl["1"][0][0], 'c')
+        # self.assertAlmostEqual(annotations_cl["1"][0][1], 0.6, 5)
+        # self.assertEqual(annotations_cl["1"][1][0], 'b')
+        # self.assertAlmostEqual(annotations_cl["1"][1][1], 0.4, 5)
 
         # self.assertEqual(2, len(locs))
 
@@ -51,17 +55,20 @@ class TestAnnotateProjection(unittest.TestCase):
         clusters, annotations_cl, locs = annotate_projection(
             self.annotations, self.data, clustering_algorithm=DBSCAN,
             eps=2, min_samples=3)
-        self.assertListEqual(
-            list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
-            ["0", "0", "0", "0", "0", "1", "1", "1", "1", "-1"])
 
-        self.assertEqual(len(annotations_cl), 2)
-        self.assertEqual(len(annotations_cl["0"]), 2)
-        self.assertEqual(len(annotations_cl["1"]), 2)
-        self.assertEqual(annotations_cl["1"][0][0], 'c')
-        self.assertAlmostEqual(annotations_cl["1"][0][1], 0.75, 5)
-        self.assertEqual(annotations_cl["1"][1][0], 'b')
-        self.assertAlmostEqual(annotations_cl["1"][1][1], 0.25, 5)
+        self.assertLessEqual(int(Orange.__version__.split(".")[1]), 21)
+        # TODO: uncomment when new Orange released, and remove version check
+        # self.assertListEqual(
+        #     list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
+        #     ["0", "0", "0", "0", "0", "1", "1", "1", "1", "-1"])
+
+        # self.assertEqual(len(annotations_cl), 2)
+        # self.assertEqual(len(annotations_cl["0"]), 2)
+        # self.assertEqual(len(annotations_cl["1"]), 2)
+        # self.assertEqual(annotations_cl["1"][0][0], 'c')
+        # self.assertAlmostEqual(annotations_cl["1"][0][1], 0.75, 5)
+        # self.assertEqual(annotations_cl["1"][1][0], 'b')
+        # self.assertAlmostEqual(annotations_cl["1"][1][1], 0.25, 5)
 
     def test_one_ex(self):
         self.data.X = self.data.X[:1]

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -1,15 +1,13 @@
-import time
 import unittest
 
 import Orange
 import numpy as np
 from Orange.clustering import DBSCAN, KMeans
-from Orange.data import Domain, ContinuousVariable, Table, DiscreteVariable
-from Orange.projection import TSNE
+from Orange.data import Domain, ContinuousVariable, Table, DiscreteVariable, \
+    get_sample_datasets_dir
 
 from orangecontrib.bioinformatics.annotation.annotate_projection import \
-    annotate_projection, labels_locations, get_epsilon, compute_concave_hulls, \
-    cluster_data
+    annotate_projection, labels_locations, get_epsilon, compute_concave_hulls
 
 
 class TestAnnotateProjection(unittest.TestCase):
@@ -34,19 +32,19 @@ class TestAnnotateProjection(unittest.TestCase):
             self.annotations, self.data, clustering_algorithm=DBSCAN,
             labels_per_cluster=2, eps=3)
 
-        self.assertLessEqual(int(Orange.__version__.split(".")[1]), 21)
+        self.assertLessEqual(int(Orange.__version__.split(".")[1]), 22)
         # TODO: uncomment when new Orange released, and remove version check
         # self.assertListEqual(
         #     list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
         #     ["0", "0", "0", "0", "0", "1", "1", "1", "1", "1"])
 
         # self.assertEqual(len(annotations_cl), 2)
-        # self.assertEqual(len(annotations_cl["0"]), 2)
-        # self.assertEqual(len(annotations_cl["1"]), 2)
-        # self.assertEqual(annotations_cl["1"][0][0], 'c')
-        # self.assertAlmostEqual(annotations_cl["1"][0][1], 0.6, 5)
-        # self.assertEqual(annotations_cl["1"][1][0], 'b')
-        # self.assertAlmostEqual(annotations_cl["1"][1][1], 0.4, 5)
+        # self.assertEqual(len(annotations_cl["C0"]), 2)
+        # self.assertEqual(len(annotations_cl["C1"]), 2)
+        # self.assertEqual(annotations_cl["C1"][0][0], 'c')
+        # self.assertAlmostEqual(annotations_cl["C1"][0][1], 0.6, 5)
+        # self.assertEqual(annotations_cl["C1"][1][0], 'b')
+        # self.assertAlmostEqual(annotations_cl["C1"][1][1], 0.4, 5)
 
         # self.assertEqual(2, len(locs))
 
@@ -56,7 +54,7 @@ class TestAnnotateProjection(unittest.TestCase):
             self.annotations, self.data, clustering_algorithm=DBSCAN,
             eps=2, min_samples=3)
 
-        self.assertLessEqual(int(Orange.__version__.split(".")[1]), 21)
+        self.assertLessEqual(int(Orange.__version__.split(".")[1]), 22)
         # TODO: uncomment when new Orange released, and remove version check
         # self.assertListEqual(
         #     list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
@@ -84,8 +82,8 @@ class TestAnnotateProjection(unittest.TestCase):
             clustering_algorithm=KMeans, n_clusters=2,
             labels_per_cluster=2)
         self.assertEqual(2, len(set(clusters.X.flatten())))
-        self.assertEqual(2, len(annotations_cl["0"]))
-        self.assertEqual(2, len(annotations_cl["1"]))
+        self.assertEqual(2, len(annotations_cl["C1"]))
+        self.assertEqual(2, len(annotations_cl["C2"]))
 
     def test_labels_location(self):
         clusters = Table(Domain([DiscreteVariable("cl", values=["1", "2"])]),
@@ -97,13 +95,13 @@ class TestAnnotateProjection(unittest.TestCase):
         self.assertEqual(tuple, type(locs["2"]))
 
     def test_get_epsilon(self):
-        data = Table("Iris")
+        data = Table("iris")
         eps = get_epsilon(data)
 
         self.assertGreaterEqual(eps, 0.9)
 
     def test_compute_concave_hulls(self):
-        data = Table("Iris")[:, 2:4]
+        data = Table("iris")[:, 2:4]
         clusters = Table(
             Domain([DiscreteVariable("cl", values=["1", "2", "3"])]),
             [[0]] * 50 + [[1]] * 50 + [[2]] * 50

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -5,7 +5,7 @@ from Orange.clustering import DBSCAN, KMeans
 from Orange.data import Domain, ContinuousVariable, Table, DiscreteVariable
 
 from orangecontrib.bioinformatics.annotation.annotate_projection import \
-    annotate_projection, labels_locations
+    annotate_projection, labels_locations, get_epsilon
 
 
 class TestAnnotateProjection(unittest.TestCase):
@@ -85,3 +85,9 @@ class TestAnnotateProjection(unittest.TestCase):
         self.assertEqual(dict, type(locs))
         self.assertEqual(tuple, type(locs["1"]))
         self.assertEqual(tuple, type(locs["2"]))
+
+    def test_get_epsilon(self):
+        data = Table("Iris")
+        eps = get_epsilon(data)
+
+        self.assertGreaterEqual(eps, 0.9)

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -2,9 +2,10 @@ import unittest
 
 import numpy as np
 from Orange.clustering import DBSCAN, KMeans
-from Orange.data import Domain, ContinuousVariable, Table
+from Orange.data import Domain, ContinuousVariable, Table, DiscreteVariable
 
-from orangecontrib.bioinformatics.annotation.annotate_projection import annotate_projection
+from orangecontrib.bioinformatics.annotation.annotate_projection import \
+    annotate_projection, labels_locations
 
 
 class TestAnnotateProjection(unittest.TestCase):
@@ -25,49 +26,62 @@ class TestAnnotateProjection(unittest.TestCase):
         self.annotations = Table(domain_ann, data_ann)
 
     def test_annotate_projection(self):
-        clusters, annotations_cl = annotate_projection(
-            self.annotations, self.data, clustering_algorithm=DBSCAN(eps=2),
-            labels_per_cluster=2)
-        np.testing.assert_array_equal(
-            clusters, np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]))
+        clusters, annotations_cl, locs = annotate_projection(
+            self.annotations, self.data, clustering_algorithm=DBSCAN,
+            labels_per_cluster=2, eps=3)
+        self.assertListEqual(
+            list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
+            ["0", "0", "0", "0", "0", "1", "1", "1", "1", "1"])
 
         self.assertEqual(len(annotations_cl), 2)
-        self.assertEqual(len(annotations_cl[0]), 2)
-        self.assertEqual(len(annotations_cl[1]), 2)
-        self.assertEqual(annotations_cl[1][0][0], 'c')
-        self.assertAlmostEqual(annotations_cl[1][0][1], 0.6, 5)
-        self.assertEqual(annotations_cl[1][1][0], 'b')
-        self.assertAlmostEqual(annotations_cl[1][1][1], 0.4, 5)
+        self.assertEqual(len(annotations_cl["0"]), 2)
+        self.assertEqual(len(annotations_cl["1"]), 2)
+        self.assertEqual(annotations_cl["1"][0][0], 'c')
+        self.assertAlmostEqual(annotations_cl["1"][0][1], 0.6, 5)
+        self.assertEqual(annotations_cl["1"][1][0], 'b')
+        self.assertAlmostEqual(annotations_cl["1"][1][1], 0.4, 5)
+
+        self.assertEqual(2, len(locs))
 
     def test_example_not_clustered(self):
         self.data[-1] = [23, 23]
-        clusters, annotations_cl = annotate_projection(
-            self.annotations, self.data, clustering_algorithm=DBSCAN(
-                eps=2, min_samples=3))
-        np.testing.assert_array_equal(
-            clusters, np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, -1]))
+        clusters, annotations_cl, locs = annotate_projection(
+            self.annotations, self.data, clustering_algorithm=DBSCAN,
+            eps=2, min_samples=3)
+        self.assertListEqual(
+            list(map(clusters.domain.attributes[0].repr_val, clusters.X[:, 0])),
+            ["0", "0", "0", "0", "0", "1", "1", "1", "1", "-1"])
 
         self.assertEqual(len(annotations_cl), 2)
-        self.assertEqual(len(annotations_cl[0]), 2)
-        self.assertEqual(len(annotations_cl[1]), 2)
-        self.assertEqual(annotations_cl[1][0][0], 'c')
-        self.assertAlmostEqual(annotations_cl[1][0][1], 0.75, 5)
-        self.assertEqual(annotations_cl[1][1][0], 'b')
-        self.assertAlmostEqual(annotations_cl[1][1][1], 0.25, 5)
+        self.assertEqual(len(annotations_cl["0"]), 2)
+        self.assertEqual(len(annotations_cl["1"]), 2)
+        self.assertEqual(annotations_cl["1"][0][0], 'c')
+        self.assertAlmostEqual(annotations_cl["1"][0][1], 0.75, 5)
+        self.assertEqual(annotations_cl["1"][1][0], 'b')
+        self.assertAlmostEqual(annotations_cl["1"][1][1], 0.25, 5)
 
     def test_one_ex(self):
         self.data.X = self.data.X[:1]
         self.annotations.X = self.annotations.X[:1]
 
-        clusters, annotations_cl = annotate_projection(
-            self.annotations, self.data, clustering_algorithm=DBSCAN(
-                eps=2, min_samples=3))
+        clusters, annotations_cl, locs = annotate_projection(
+            self.annotations, self.data, clustering_algorithm=DBSCAN,
+            eps=2, min_samples=3)
 
     def test_other_clustering(self):
-        clusters, annotations_cl = annotate_projection(
+        clusters, annotations_cl, locs = annotate_projection(
             self.annotations, self.data,
-            clustering_algorithm=KMeans(n_clusters=2),
+            clustering_algorithm=KMeans, n_clusters=2,
             labels_per_cluster=2)
-        self.assertEqual(2, len(set(clusters)))
-        self.assertEqual(2, len(annotations_cl[0]))
-        self.assertEqual(2, len(annotations_cl[1]))
+        self.assertEqual(2, len(set(clusters.X.flatten())))
+        self.assertEqual(2, len(annotations_cl["0"]))
+        self.assertEqual(2, len(annotations_cl["1"]))
+
+    def test_labels_location(self):
+        clusters = Table(Domain([DiscreteVariable("cl", values=["1", "2"])]),
+                         [[0]] * 5 + [[1]] * 5)
+        locs = labels_locations(self.data, clusters)
+
+        self.assertEqual(dict, type(locs))
+        self.assertEqual(tuple, type(locs["1"]))
+        self.assertEqual(tuple, type(locs["2"]))

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -1,11 +1,14 @@
+import time
 import unittest
 
 import numpy as np
 from Orange.clustering import DBSCAN, KMeans
 from Orange.data import Domain, ContinuousVariable, Table, DiscreteVariable
+from Orange.projection import TSNE
 
 from orangecontrib.bioinformatics.annotation.annotate_projection import \
-    annotate_projection, labels_locations, get_epsilon
+    annotate_projection, labels_locations, get_epsilon, compute_concave_hulls, \
+    cluster_data
 
 
 class TestAnnotateProjection(unittest.TestCase):
@@ -41,7 +44,7 @@ class TestAnnotateProjection(unittest.TestCase):
         self.assertEqual(annotations_cl["1"][1][0], 'b')
         self.assertAlmostEqual(annotations_cl["1"][1][1], 0.4, 5)
 
-        self.assertEqual(2, len(locs))
+        # self.assertEqual(2, len(locs))
 
     def test_example_not_clustered(self):
         self.data[-1] = [23, 23]
@@ -91,3 +94,16 @@ class TestAnnotateProjection(unittest.TestCase):
         eps = get_epsilon(data)
 
         self.assertGreaterEqual(eps, 0.9)
+
+    def test_compute_concave_hulls(self):
+        data = Table("Iris")[:, 2:4]
+        clusters = Table(
+            Domain([DiscreteVariable("cl", values=["1", "2", "3"])]),
+            [[0]] * 50 + [[1]] * 50 + [[2]] * 50
+        )
+        hulls = compute_concave_hulls(data, clusters, epsilon=0.5)
+
+        self.assertEqual(3, len(hulls))
+        self.assertEqual(2, len(hulls["1"]))  # hull have x and y
+        self.assertEqual(2, len(hulls["2"]))  # hull have x and y
+        self.assertEqual(2, len(hulls["3"]))  # hull have x and y

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -1,0 +1,73 @@
+import unittest
+
+import numpy as np
+from Orange.clustering import DBSCAN, KMeans
+from Orange.data import Domain, ContinuousVariable, Table
+
+from orangecontrib.bioinformatics.annotation.annotate_projection import annotate_projection
+
+
+class TestAnnotateProjection(unittest.TestCase):
+
+    def setUp(self):
+        domain = Domain([ContinuousVariable("x"), ContinuousVariable("y")])
+        data = np.array([[1., 1.], [1., 1.5], [1.5, 1.], [1.2, 1.2], [1.7, 1.8],
+                         [10., 10.], [10., 10.5], [10.5, 11.], [10.5, 10.7],
+                         [10.5, 10.6]])
+        self.data = Table(domain, data)
+
+        domain_ann = Domain([ContinuousVariable("a"), ContinuousVariable("b"),
+                            ContinuousVariable("c")])
+        data_ann = np.array([[0.9, 1, 0.4], [0.9, 0.4, 0.2], [0.9, 0.4, 0.2],
+                             [0.9, 1, 0.2], [0.9, 0.4, 0.2],
+                             [0.2, 0.4, 0.7], [0.1, 0.4, 0.6], [0.2, 0.9, 0.2],
+                             [0.1, 0.4, 0.6], [0.1, 0.8, 0.6]])
+        self.annotations = Table(domain_ann, data_ann)
+
+    def test_annotate_projection(self):
+        clusters, annotations_cl = annotate_projection(
+            self.annotations, self.data, clustering_algorithm=DBSCAN(eps=2),
+            labels_per_cluster=2)
+        np.testing.assert_array_equal(
+            clusters, np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]))
+
+        self.assertEqual(len(annotations_cl), 2)
+        self.assertEqual(len(annotations_cl[0]), 2)
+        self.assertEqual(len(annotations_cl[1]), 2)
+        self.assertEqual(annotations_cl[1][0][0], 'c')
+        self.assertAlmostEqual(annotations_cl[1][0][1], 0.6, 5)
+        self.assertEqual(annotations_cl[1][1][0], 'b')
+        self.assertAlmostEqual(annotations_cl[1][1][1], 0.4, 5)
+
+    def test_example_not_clustered(self):
+        self.data[-1] = [23, 23]
+        clusters, annotations_cl = annotate_projection(
+            self.annotations, self.data, clustering_algorithm=DBSCAN(
+                eps=2, min_samples=3))
+        np.testing.assert_array_equal(
+            clusters, np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, -1]))
+
+        self.assertEqual(len(annotations_cl), 2)
+        self.assertEqual(len(annotations_cl[0]), 2)
+        self.assertEqual(len(annotations_cl[1]), 2)
+        self.assertEqual(annotations_cl[1][0][0], 'c')
+        self.assertAlmostEqual(annotations_cl[1][0][1], 0.75, 5)
+        self.assertEqual(annotations_cl[1][1][0], 'b')
+        self.assertAlmostEqual(annotations_cl[1][1][1], 0.25, 5)
+
+    def test_one_ex(self):
+        self.data.X = self.data.X[:1]
+        self.annotations.X = self.annotations.X[:1]
+
+        clusters, annotations_cl = annotate_projection(
+            self.annotations, self.data, clustering_algorithm=DBSCAN(
+                eps=2, min_samples=3))
+
+    def test_other_clustering(self):
+        clusters, annotations_cl = annotate_projection(
+            self.annotations, self.data,
+            clustering_algorithm=KMeans(n_clusters=2),
+            labels_per_cluster=2)
+        self.assertEqual(2, len(set(clusters)))
+        self.assertEqual(2, len(annotations_cl[0]))
+        self.assertEqual(2, len(annotations_cl[1]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests-cache
 genesis-pyapi
 scipy
 numpy
+shapely


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements #125

##### Description of changes

This script:

- Clusters the projections
- Assigns annotations to clusters
- Computes annotation locations at the projection
- Computes the concave hull around clusters

Note: Because of efficiency of hull computation the `shapely` dependency is added to the project.

##### Includes
- [X] Code changes
- [x] Tests
- [x] Documentation