### PR TITLE
[FIX] AnnotateSamples: Adopt for int entrez ID in dataset

### DIFF
--- a/orangecontrib/bioinformatics/annotation/annotate_samples.py
+++ b/orangecontrib/bioinformatics/annotation/annotate_samples.py
@@ -134,7 +134,10 @@ class AnnotateSamples:
         attributes_np = np.array([
             a.attributes.get("Entrez ID") for a in data.domain.attributes])
         attributes_sets = [
-            set(attributes_np[row > z_threshold]) - {None} for row in z]
+            set(map(str, set(attributes_np[row > z_threshold]) - {None}))
+            for row in z]
+        # map to string was added since there seems to be no guarantee that
+        # Entrez ID is a string.
 
         # pack z values to data table
         # take only attributes in new domain

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_samples.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_samples.py
@@ -193,3 +193,22 @@ class TestAnnotateSamples(unittest.TestCase):
     def test_log_cpm(self):
         norm_data = self.annotator.log_cpm(self.data)
         self.assertTupleEqual(self.data.X.shape, norm_data.X.shape)
+
+    def test_entrez_id_not_string(self):
+        """
+        It seems that some datasets (e.g. AML dataset) have Entrez ID as int
+        although they should be strings. Here we add the test for those cases.
+        """
+        # change Entrez IDs to int
+        for i, att in enumerate(self.data.domain.attributes):
+            att.attributes["Entrez ID"] = int(att.attributes["Entrez ID"])
+
+        annotations = self.annotator.annotate_samples(self.data,
+                                                      self.markers)
+
+        self.assertEqual(type(annotations), Table)
+        self.assertEqual(len(annotations), len(self.data))
+        self.assertEqual(len(annotations[0]), 2)  # two types in the data
+        self.assertGreater(annotations.X.sum(), 0)
+        self.assertLessEqual(annotations.X.max(), 1)
+        self.assertGreaterEqual(annotations.X.min(), 0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It seems some datasets (like AML) has int entre IDs. AnnotateSamples expected them to be strings.

##### Description of changes

With this PR AnnotateSamples will work for int Entrez IDs too.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
