### PR TITLE
AnnotateSamples: Filter values that have higher p-value with nan

### DIFF
--- a/orangecontrib/bioinformatics/annotation/annotate_samples.py
+++ b/orangecontrib/bioinformatics/annotation/annotate_samples.py
@@ -360,13 +360,13 @@ class AnnotateSamples:
             Filtered scores for each annotations for each cell
         """
         scores_x = np.copy(scores.X)  # do not want to edit values inplace
-        scores_x[p_values.X > p_threshold] = 0
-        probs = Table(scores.domain, scores_x)
+        scores_x[p_values.X > p_threshold] = np.nan
+        scores = Table(scores.domain, scores_x)
 
         if return_nonzero_annotations:
-            col_nonzero = np.sum(probs, axis=0) > 0
+            col_not_empty = ~np.isnan(scores).all(axis=0)
             new_domain = Domain(
-                np.array(scores.domain.attributes)[col_nonzero])
+                np.array(scores.domain.attributes)[col_not_empty])
             scores = Table(new_domain, scores)
         return scores
 

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_samples.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_samples.py
@@ -47,11 +47,14 @@ class TestAnnotateSamples(unittest.TestCase):
         self.assertEqual(type(annotations), Table)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 2)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
 
     def test_remove_empty_column(self):
+        """
+        Type 3 column must be removed here
+        """
         m_domain = Domain(
             [], None, [
                 StringVariable("Cell Type"), StringVariable("Entrez ID")])
@@ -67,17 +70,17 @@ class TestAnnotateSamples(unittest.TestCase):
         self.assertEqual(type(annotations), Table)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 2)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
 
         annotations = self.annotator.annotate_samples(
             self.data, markers, return_nonzero_annotations=False)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 3)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
 
     def test_sf(self):
         """
@@ -90,9 +93,9 @@ class TestAnnotateSamples(unittest.TestCase):
         self.assertEqual(type(annotations), Table)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 2)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
 
     def test_two_example(self):
         self.data.X = self.data.X[:2]
@@ -110,9 +113,9 @@ class TestAnnotateSamples(unittest.TestCase):
         self.assertEqual(type(annotations), Table)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 2)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
 
     def test_select_attributes(self):
         z = self.annotator.mann_whitney_test(self.data)
@@ -162,9 +165,9 @@ class TestAnnotateSamples(unittest.TestCase):
         self.assertEqual(type(annotations), Table)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 2)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
 
         # scoring SCORING_MARKERS_SUM
         annotations = self.annotator.annotate_samples(
@@ -176,12 +179,8 @@ class TestAnnotateSamples(unittest.TestCase):
 
         # based on provided data it should match
         # the third row is skipped, since it is special
-        self.assertAlmostEqual(annotations[0, 0].value, self.data.X[0].sum())
-        self.assertAlmostEqual(annotations[1, 0].value, self.data.X[1].sum())
-        self.assertAlmostEqual(annotations[2, 0].value, self.data.X[2].sum())
-        self.assertAlmostEqual(annotations[4, 1].value, self.data.X[4].sum())
-        self.assertAlmostEqual(annotations[5, 1].value, self.data.X[5].sum())
-        self.assertAlmostEqual(annotations[6, 1].value, self.data.X[6].sum())
+        self.assertEqual(annotations[0, 0].value, self.data.X[0].sum())
+        self.assertEqual(annotations[5, 1].value, self.data.X[5].sum())
 
         # scoring SCORING_LOG_FDR
         annotations = self.annotator.annotate_samples(
@@ -218,6 +217,7 @@ class TestAnnotateSamples(unittest.TestCase):
         self.assertEqual(type(annotations), Table)
         self.assertEqual(len(annotations), len(self.data))
         self.assertEqual(len(annotations[0]), 2)  # two types in the data
-        self.assertGreater(annotations.X.sum(), 0)
-        self.assertLessEqual(annotations.X.max(), 1)
-        self.assertGreaterEqual(annotations.X.min(), 0)
+        self.assertGreater(np.nansum(annotations.X), 0)
+        self.assertLessEqual(np.nanmax(annotations.X), 1)
+        self.assertGreaterEqual(np.nanmin(annotations.X), 0)
+


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Before values that have higher p-value with threshold were filtered out with 0.
It is not a good practice since zero has meaning when scoring is log(FDR) or log(P-value).

##### Description of changes

This PR changes filtering out to use nans instead of 0.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
