### PR TITLE
Annotator: Remove shapely

### DIFF
--- a/.azure-pipelines/install_addon.yml
+++ b/.azure-pipelines/install_addon.yml
@@ -12,7 +12,6 @@ steps:
     continueOnError: false
 
 - script: |
-    pip install https://download.lfd.uci.edu/pythonlibs/t4jqbe6o/Shapely-1.6.4.post2-cp37-cp37m-win_amd64.whl
     pip install -r requirements.txt
     pip install PyQt5~=5.9.0
     pip install sphinx recommonmark

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,6 @@ jobs:
     name: macOS
     vmImage: 'macOS-10.14'
 
-# For now, testing on windows is broken because pypi package shapely fails to install on windows (no binary provided on pypi).
-# current workaround is to use wheel from: https://download.lfd.uci.edu/pythonlibs/t4jqbe6o/Shapely-1.6.4.post2-cp37-cp37m-win_amd64.whl
 - template: .azure-pipelines/jobs.yml
   parameters:
     name: Windows

--- a/orangecontrib/bioinformatics/tests/widgets/test_OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/tests/widgets/test_OWAnnotateProjection.py
@@ -48,14 +48,14 @@ class TestOWAnnotateProjection(WidgetTest, ProjectionWidgetTestMixin,
         self.send_signal(self.widget.Inputs.projector, None)
         self.send_signal(self.widget.Inputs.genes, self.genes)
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.wait_until_stop_blocking()
+        self.wait_until_stop_blocking(wait=10000)
         self.assertFalse(self.widget.Error.proj_error.is_shown())
         self.assertIsNotNone(self.widget.embedding)
         self.send_signal(self.widget.Inputs.projector, PCA())
         self.assertIsInstance(self.widget.projector, PCA)
-        self.wait_until_stop_blocking()
+        self.wait_until_stop_blocking(wait=10000)
         self.send_signal(self.widget.Inputs.projector, MDS())
-        self.wait_until_stop_blocking()
+        self.wait_until_stop_blocking(wait=10000)
         self.assertTrue(self.widget.Error.proj_error.is_shown())
 
     def test_input_genes(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ requests-cache>=0.5.0
 genesis-pyapi>=1.2.1
 scipy>=1.3.0
 numpy>=1.16.4
-shapely>=1.6.4
+pyclipper


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-bioinformatics/issues/152

##### Description of changes

Shapely was replaced with pyclipper which makes buffering (make an offset of the polygon-hull) and part of the Shapely's task (joining triangles in polygon) is made manually now.

Pyclipper is also c/cyton based library but has all wheels available - for Windows too.

In this pull request, I also increase the wait time in one of the tests or the Annotator widget. It was required since this test usually failed due to time out. I found out that this is not connected with changes in this PR. This test kept failing before changes.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
