### PR TITLE
[FIX] OwAnnotator: Fix label locations to be in the center of the cluster

### DIFF
--- a/orangecontrib/bioinformatics/annotation/annotate_projection.py
+++ b/orangecontrib/bioinformatics/annotation/annotate_projection.py
@@ -189,7 +189,8 @@ def labels_locations(coordinates, clusters):
             map(clusters.domain.attributes[0].repr_val,
                 clusters.X[:, 0]))).flatten() == cl
         cl_coordinates = coordinates.X[mask, :]
-        x, y = np.mean(cl_coordinates, axis=0)
+        x, y = 1/2 * (
+                np.min(cl_coordinates, axis=0) + np.max(cl_coordinates, axis=0))
         locations[cl] = (x, y)
     return locations
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since label locations were computed as a cluster mean they were not exactly in the center of the cluster.

##### Description of changes

Location is now computed as an average of max and min value of the cluster.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
