### PR TITLE
[FIX] OWAnnotator: Compute epsilon with smaller k when not enough data items.

### DIFF
--- a/orangecontrib/bioinformatics/annotation/annotate_projection.py
+++ b/orangecontrib/bioinformatics/annotation/annotate_projection.py
@@ -219,7 +219,8 @@ def get_epsilon(coordinates, k=10, skip=0.1):
         x = x[::i]
 
     d = distance.squareform(distance.pdist(x))
-    kth_point = np.argpartition(d, k+1, axis=1)[:, k+1]
+    k = min(k+1, len(coordinates) - 1)
+    kth_point = np.argpartition(d, k, axis=1)[:, k]
     # k+1 since first one is item itself
     kth_dist = np.sort(d[np.arange(0, len(kth_point)), kth_point])
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Annotator faild to copute the clustering epsilone when not enough data items present.

##### Description of changes

Compute epsilon on the smaller neighborhood when not enough data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
