### PR TITLE
[ENH] OWGenes: Speed up commit

### DIFF
--- a/orangecontrib/bioinformatics/ncbi/gene/__init__.py
+++ b/orangecontrib/bioinformatics/ncbi/gene/__init__.py
@@ -144,7 +144,8 @@ class GeneMatcher:
 
         genes: List[Gene] = self.genes
         if selected_genes is not None:
-            genes = [gene for gene in self.genes if str(gene.gene_id) in selected_genes]
+            selected_genes_set = set(selected_genes)
+            genes = [gene for gene in self.genes if str(gene.gene_id) in selected_genes_set]
 
         for gene in genes:
             db_refs = (

--- a/orangecontrib/bioinformatics/widgets/OWGenes.py
+++ b/orangecontrib/bioinformatics/widgets/OWGenes.py
@@ -549,8 +549,10 @@ class OWGenes(OWWidget, ConcurrentWidgetMixin):
                 col[:] = gene_ids
 
                 # filter selected rows
+                selected_genes_set = set(selected_genes)
                 selected_rows = [
-                    row_index for row_index, row in enumerate(table) if str(row[gene_var]) in selected_genes
+                    row_index for row_index, row in enumerate(table)
+                    if str(row[gene_var]) in selected_genes_set
                 ]
 
                 # handle table attributes
@@ -587,11 +589,12 @@ class OWGenes(OWWidget, ConcurrentWidgetMixin):
                                 pass
 
                 # filter selected columns
+                selected_genes_set = set(selected_genes)
                 selected = [
                     column
                     for column in table.domain.attributes
                     if self.target_database in column.attributes
-                    and str(column.attributes[self.target_database]) in selected_genes
+                    and str(column.attributes[self.target_database]) in selected_genes_set
                 ]
 
                 output_attrs = table.domain.attributes
@@ -600,7 +603,11 @@ class OWGenes(OWWidget, ConcurrentWidgetMixin):
                     output_attrs = selected
 
                 if self.exclude_unmatched:
-                    output_attrs = [col for col in output_attrs if col.attributes[self.target_database] in known_genes]
+                    known_genes_set = set(known_genes)
+                    output_attrs = [
+                        col for col in output_attrs
+                        if col.attributes[self.target_database] in known_genes_set
+                    ]
 
                 domain = Domain(output_attrs, table.domain.class_vars, table.domain.metas)
 
@@ -632,9 +639,13 @@ if __name__ == "__main__":
 
     def main_test():
         from AnyQt.QtWidgets import QApplication
+        import sys
 
         app = QApplication([])
         w = OWGenes()
+        if len(sys.argv) > 1:
+            data = Table(sys.argv[1])
+            w.handle_input(data)
         w.show()
         w.raise_()
         r = app.exec_()


### PR DESCRIPTION
##### Issue
The "Genes" widget is slow. While the gene matching happens in a separate thread, `commit` still runs on the GUI thread. Unfortunately, `commit` is slow, and freezes everything for a while when dealing with large numbers of genes.


##### Description of changes

Running the profiler, I quickly found out that list comprehensions of the form `[... for gene in genes if g in <something>]` where "something" was a long list. List lookups are slow, so replacing these with `set` instances sped up things dramatically.

E.g. the runtime for [xin2016 sample](http://file.biolab.si/scdata/xin2016_pancreas_human_sample.tab.gz) is reduced from ~45sec to ~7sec.

Obviously, ideally, we would have all this more compute-heavy code run in a separate thread, but that would require a bit more effort.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
