### PR TITLE
[ENH] Point-annotator 2.0.0 and support for sparse data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
             'genesis-pyapi==1.2.1',
             'pyclipper==1.1.0.post1',
             'Orange3>=3.22.0',
-            'point-annotator~=1.0',
+            'point-annotator~=2.0',
             # Versions are determined by Orange
             'scipy',
             'numpy',


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Annotator do not support sparse data. 
Breaking changes in point-annotator 2.0.0

##### Description of changes
- Switching to point-annotator 2.0.0
- Supporting sparse data tables
- Tests for sparse data

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
