### PR TITLE
[FIX] Annotator: fix palette and output

### DIFF
--- a/orangecontrib/bioinformatics/tests/widgets/test_OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/tests/widgets/test_OWAnnotateProjection.py
@@ -24,6 +24,7 @@ class TestOWAnnotateProjection(WidgetTest, ProjectionWidgetTestMixin, WidgetOutp
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        WidgetOutputsTestMixin.init(cls)
         cls._init_data()
         cls.signal_name = "Reference Data"
         cls.signal_data = cls.data


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Annotator failed on creating the output and on coloring based on cluster.

##### Description of changes
- fixing palette for colour by cluster
- the redundant parameter on the function that creates output removed 
- replacing deprecated calls

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
