### PR TITLE
[FIX] OWGEODatasets: Remove `wrap` reimplementation

### DIFF
--- a/orangecontrib/bioinformatics/widgets/OWGEODatasets.py
+++ b/orangecontrib/bioinformatics/widgets/OWGEODatasets.py
@@ -215,13 +215,6 @@ class GEODatasetsModel(itemmodels.PyTableModel):
         self.wrap(self.table[self.filter_table(filter_pattern).any(axis=1), :])
         self.sort(self._sort_column, self._sort_order)
 
-    def wrap(self, table):
-        self.beginResetModel()
-        self._table = table
-        self._roleData = self._RoleData()
-        self.resetSorting()
-        self.endResetModel()
-
 
 class OWGEODatasets(OWWidget, ConcurrentWidgetMixin):
     name = "GEO Data Sets"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-239

##### Description of changes

Remove `wrap` reimplementation, it seems to be just a copy of base implementation before https://github.com/biolab/orange3/pull/4474

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
