### PR TITLE
[FIX] Marker genes: settings migration

### DIFF
--- a/orangecontrib/bioinformatics/tests/widgets/test_OWMarkerGenes.py
+++ b/orangecontrib/bioinformatics/tests/widgets/test_OWMarkerGenes.py
@@ -9,7 +9,8 @@ from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 
-from orangecontrib.bioinformatics.widgets.OWMarkerGenes import TreeItem, TreeView, OWMarkerGenes
+from orangecontrib.bioinformatics.utils import serverfiles
+from orangecontrib.bioinformatics.widgets.OWMarkerGenes import SERVER_FILES_DOMAIN, TreeItem, TreeView, OWMarkerGenes
 
 
 class TestTreeItem(unittest.TestCase):
@@ -217,6 +218,20 @@ class TestTreeItem(unittest.TestCase):
 
 
 class TestOWMarkerGenes(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        """ Code executed only once for all tests """
+        super().setUpClass()
+        file_name = "panglao_gene_markers.tab"
+        serverfiles.update(SERVER_FILES_DOMAIN, file_name)
+        file_path = serverfiles.localpath_download(SERVER_FILES_DOMAIN, file_name)
+        cls.panglao = Table.from_file(file_path)
+
+        file_name = "cellMarker_gene_markers.tab"
+        serverfiles.update(SERVER_FILES_DOMAIN, file_name)
+        file_path = serverfiles.localpath_download(SERVER_FILES_DOMAIN, file_name)
+        cls.cell_markers = Table.from_file(file_path)
+
     def setUp(self):
         self.widget = self.create_widget(OWMarkerGenes)
 
@@ -268,19 +283,19 @@ class TestOWMarkerGenes(WidgetTest):
         # cell marker data
         self.assertEqual("Panglao", self.widget.db_source_cb.currentText())
         self.assertTrue(isinstance(self.widget.data, Table))
-        self.assertEqual(15669, len(self.widget.data))
+        self.assertEqual(len(self.panglao), len(self.widget.data))
 
         # Panglao data
         simulate.combobox_activate_index(self.widget.controls.source_index, 1)
         self.assertEqual("CellMarker", self.widget.db_source_cb.currentText())
         self.assertTrue(isinstance(self.widget.data, Table))
-        self.assertEqual(41457, len(self.widget.data))
+        self.assertEqual(len(self.cell_markers), len(self.widget.data))
 
         # cell marker data
         simulate.combobox_activate_index(self.widget.controls.source_index, 0)
         self.assertEqual("Panglao", self.widget.db_source_cb.currentText())
         self.assertTrue(isinstance(self.widget.data, Table))
-        self.assertEqual(15669, len(self.widget.data))
+        self.assertEqual(len(self.panglao), len(self.widget.data))
 
     def test_organism_changed(self):
         """
@@ -295,7 +310,7 @@ class TestOWMarkerGenes(WidgetTest):
         cell_types = self.widget.data.get_column_view("Cell Type")[0]
 
         model = self.widget.available_markers_view.model().sourceModel()
-        self.assertEqual(7795, len(model))
+        self.assertEqual(sum(self.panglao.get_column_view("Organism")[0] == "Human"), len(model))
         self.assertEqual(len(np.unique(cell_types[human_rows])), len(model.rootItem.childItems))
 
         simulate.combobox_activate_index(self.widget.controls.source_index, 0)
@@ -304,7 +319,7 @@ class TestOWMarkerGenes(WidgetTest):
         self.assertEqual("Mouse", self.widget.group_cb.currentText())
 
         model = self.widget.available_markers_view.model().sourceModel()
-        self.assertEqual(7874, len(model))
+        self.assertEqual(sum(self.panglao.get_column_view("Organism")[0] == "Mouse"), len(model))
         self.assertEqual(len(np.unique(cell_types[~human_rows])), len(model.rootItem.childItems))
 
         simulate.combobox_activate_index(self.widget.controls.source_index, 1)
@@ -316,7 +331,7 @@ class TestOWMarkerGenes(WidgetTest):
         cell_types = self.widget.data.get_column_view("Cell Type")[0]
 
         model = self.widget.available_markers_view.model().sourceModel()
-        self.assertEqual(26138, len(model))
+        self.assertEqual(sum(self.cell_markers.get_column_view("Organism")[0] == "Human"), len(model))
         self.assertEqual(len(np.unique(cell_types[human_rows])), len(model.rootItem.childItems))
 
         simulate.combobox_activate_index(self.widget.controls.source_index, 1)
@@ -325,7 +340,7 @@ class TestOWMarkerGenes(WidgetTest):
         self.assertEqual("Mouse", self.widget.group_cb.currentText())
 
         model = self.widget.available_markers_view.model().sourceModel()
-        self.assertEqual(15319, len(model))
+        self.assertEqual(sum(self.cell_markers.get_column_view("Organism")[0] == "Mouse"), len(model))
         self.assertEqual(len(np.unique(cell_types[~human_rows])), len(model.rootItem.childItems))
 
     def test_group_by_changed(self):

--- a/orangecontrib/bioinformatics/widgets/OWMarkerGenes.py
+++ b/orangecontrib/bioinformatics/widgets/OWMarkerGenes.py
@@ -733,14 +733,12 @@ class OWMarkerGenes(widget.OWWidget):
     want_main_area = True
     want_control_area = True
 
-    organism_index = Setting(0)
-    source_index = Setting(0)
     auto_commit = Setting(True)
     selected_source = Setting("")
     selected_organism = Setting("")
     selected_root_attribute = Setting(0)
 
-    settingsHandler = MarkerGroupContextHandler()
+    settingsHandler = MarkerGroupContextHandler()  # noqa: N815
     selected_genes = settings.ContextSetting([])
 
     _data = None
@@ -808,10 +806,12 @@ class OWMarkerGenes(widget.OWWidget):
         Function defines dropdowns and the button in the control area.
         """
         box = gui.widgetBox(self.controlArea, 'Database', margin=0)
+        self.source_index = -1
         self.db_source_cb = gui.comboBox(box, self, 'source_index')
         self.db_source_cb.activated[int].connect(self._set_db_source_index)
 
         box = gui.widgetBox(self.controlArea, 'Organism', margin=0)
+        self.organism_index = -1
         self.group_cb = gui.comboBox(box, self, 'organism_index')
         self.group_cb.activated[int].connect(self._set_group_index)
 
@@ -1113,6 +1113,18 @@ class OWMarkerGenes(widget.OWWidget):
         """
         rows = view.selectionModel().selectedRows()
         return list(map(view.model().mapToSource, rows))
+
+    @classmethod
+    def migrate_settings(cls, settings, version=0):
+        def migrate_to_version_2():
+            settings["selected_source"] = settings.pop("selected_db_source", "")
+            settings["selected_organism"] = settings.pop("selected_group", "")
+            if "context_settings" in settings:
+                for co in settings["context_settings"]:
+                    co.values["selected_genes"] = [g[0] + g[1] for g in co.values["selected_genes"]]
+
+        if version < 2:
+            migrate_to_version_2()
 
 
 if __name__ == "__main__":

--- a/orangecontrib/bioinformatics/widgets/OWMarkerGenes.py
+++ b/orangecontrib/bioinformatics/widgets/OWMarkerGenes.py
@@ -741,6 +741,8 @@ class OWMarkerGenes(widget.OWWidget):
     settingsHandler = MarkerGroupContextHandler()  # noqa: N815
     selected_genes = settings.ContextSetting([])
 
+    settings_version = 2
+
     _data = None
     _available_sources = None
 

--- a/orangecontrib/bioinformatics/widgets/utils/settings.py
+++ b/orangecontrib/bioinformatics/widgets/utils/settings.py
@@ -71,9 +71,13 @@ class MarkerGroupContextHandler(settings.ContextHandler):
     """
 
     def match(self, context, group_source: Tuple[str, str], *args) -> str:
-        if not context.group_source == group_source:
-            return self.NO_MATCH
-        return self.PERFECT_MATCH
+        if hasattr(context, "group_source") and context.group_source == group_source:
+            return self.PERFECT_MATCH
+        elif (
+            hasattr(context, "group") and context.group == group_source[0]
+        ):  # backward compatibility (in old widget only group was saved)
+            return self.PERFECT_MATCH
+        return self.NO_MATCH
 
     def new_context(self, group_source: Tuple[str, str]):
         context = super().new_context()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- changed settings of the widget were not migrated when the user opened older workflow
- test started to fail since marker genes data changed

##### Description of changes
- Added settings migration
- Test updated to be data change independent

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
