### PR TITLE
[FIX] AnnotateProjection: fix tests that fail due to changes in numpy

### DIFF
--- a/orangecontrib/bioinformatics/tests/widgets/test_OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/tests/widgets/test_OWAnnotateProjection.py
@@ -153,7 +153,7 @@ class TestOWAnnotateProjection(WidgetTest, ProjectionWidgetTestMixin, WidgetOutp
         output2 = self.get_output(self.widget.Outputs.annotated_data)
         np.testing.assert_array_equal(output1.X, output2.X)
         np.testing.assert_array_equal(output1.Y, output2.Y)
-        self.assertFalse((output1.metas == output2.metas).all())
+        self.assertFalse(output1.metas.shape == output2.metas.shape and np.equal(output1.metas, output2.metas).all())
         self._patch_annotation_functions()
 
     def test_p_threshold_control(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Test started to fail since arrays have different shapes

##### Description of changes
Also, compare shapes

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
