### PR TITLE
[FIX] OWGenialisExpressions: prevent full text search component to move on animation toggle

### DIFF
--- a/orangecontrib/bioinformatics/widgets/OWGenialisExpressions.py
+++ b/orangecontrib/bioinformatics/widgets/OWGenialisExpressions.py
@@ -194,6 +194,7 @@ class CollapsibleFilterComponent(OWComponent, QObject):
         self.collapsible_components.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.collapsible_components.setFrameShape(QFrame.NoFrame)
 
+        box = gui.widgetBox(parent_component, margin=0)
         box.layout().addWidget(self.toggle_button)
         box.layout().addWidget(self.collapsible_components)
 


### PR DESCRIPTION

Before:
![Screen Recording 2020-09-15 at 10 10 44](https://user-images.githubusercontent.com/15876321/93185174-60f5ab00-f73d-11ea-9f89-ea9cc84e60c1.gif)

After:
![Screen Recording 2020-09-15 at 10 11 40](https://user-images.githubusercontent.com/15876321/93185207-68b54f80-f73d-11ea-8bd6-1fe2e24b1ac1.gif)

