### PR TITLE
[FIX] Adjust for changes in widget auto-summary process

### DIFF
--- a/orangecontrib/bioinformatics/tests/kegg/test_databases.py
+++ b/orangecontrib/bioinformatics/tests/kegg/test_databases.py
@@ -19,7 +19,7 @@ class TestGenome(unittest.TestCase):
             self.assertIsInstance(entry.name, six.string_types)
             self.assertIsInstance(entry.taxid, six.string_types)
 
-        self.assertTrue(genome.search("homo sapiens")[0] == "hsa")
+        self.assertEqual(genome.search("homo sapiens")[0], "hsa")
         entry = genome['hsa']
         self.assertEqual(entry.taxid, "9606")
 

--- a/orangecontrib/bioinformatics/tests/widgets/test_OWMarkerGenes.py
+++ b/orangecontrib/bioinformatics/tests/widgets/test_OWMarkerGenes.py
@@ -1,12 +1,11 @@
 import unittest
-from unittest.mock import Mock
 
 import numpy as np
-from orangewidget.tests.base import WidgetTest
 
 from AnyQt.QtCore import QModelIndex, QItemSelectionModel
 
 from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 
 from orangecontrib.bioinformatics.utils import serverfiles
@@ -220,7 +219,7 @@ class TestTreeItem(unittest.TestCase):
 class TestOWMarkerGenes(WidgetTest):
     @classmethod
     def setUpClass(cls):
-        """ Code executed only once for all tests """
+        """Code executed only once for all tests"""
         super().setUpClass()
         file_name = "panglao_gene_markers.tab"
         serverfiles.update(SERVER_FILES_DOMAIN, file_name)
@@ -546,45 +545,6 @@ class TestOWMarkerGenes(WidgetTest):
         # description for first gene
         dest_view.selectionModel().select(gene_index, QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
         self.assertIn(first_gene_info, self.widget.descriptionlabel.toPlainText())
-
-    def test_output_info(self):
-        """
-        Test whether the output info in a status bar is set correctly.
-        """
-        # mocks
-        output_sum = self.widget.info.set_output_summary = Mock()
-
-        # views
-        src_view = self.widget.available_markers_view
-        dest_view = self.widget.selected_markers_view
-
-        # move elements
-        parent_index = src_view.model().index(0, 0)
-        gene_index = src_view.model().index(0, 0, parent_index)
-        gene_index1 = src_view.model().index(1, 0, parent_index)
-        src_view.selectionModel().select(gene_index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
-        self.widget.move_button.click()
-
-        output_sum.assert_called_with("Selected: 1")
-
-        # move one more
-        src_view.selectionModel().select(gene_index1, QItemSelectionModel.Select | QItemSelectionModel.Rows)
-        self.widget.move_button.click()
-
-        output_sum.assert_called_with("Selected: 2")
-
-        # move complete parent
-        src_view.selectionModel().select(parent_index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
-        self.widget.move_button.click()
-
-        output_sum.assert_called_with(f"Selected: {len(dest_view.model().sourceModel())}")
-
-        # move everthing back
-        parent_index = dest_view.model().index(0, 0)
-        dest_view.selectionModel().select(parent_index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
-        self.widget.move_button.click()
-
-        output_sum.assert_called_with("Selected: 0")
 
     def test_extend_collapse_both_views(self):
         """

--- a/orangecontrib/bioinformatics/widgets/OWMarkerGenes.py
+++ b/orangecontrib/bioinformatics/widgets/OWMarkerGenes.py
@@ -839,7 +839,7 @@ class OWMarkerGenes(widget.OWWidget):
         """
         self._available_sources = value
 
-        items = sorted(list(value.keys()), reverse=True)  # panglao first
+        items = sorted(value.keys(), reverse=True)  # panglao first
         try:
             idx = items.index(self.selected_source)
         except ValueError:
@@ -1036,13 +1036,6 @@ class OWMarkerGenes(widget.OWWidget):
                 f"<b>Reference:</b> <a href='{data_row['URL']}'>{data_row['Reference']}</a>"
             )
 
-    def _update_data_info(self) -> None:
-        """
-        Updates output info in the control area.
-        """
-        sel_model = self.selected_markers_view.model().sourceModel()
-        self.info.set_output_summary(f"Selected: {str(len(sel_model))}")
-
     # callback functions
 
     def _selected_markers_changed(self) -> None:
@@ -1051,7 +1044,6 @@ class OWMarkerGenes(widget.OWWidget):
         """
         rows = self.selected_markers_view.model().sourceModel().rootItem.get_data_rows()
         self.selected_genes = [row["Entrez ID"].value + row["Cell Type"].value for row in rows]
-        self._update_data_info()
         self.commit()
 
     def _on_selection_changed(self, view: TreeView) -> None:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ if __name__ == '__main__':
         setup_requires=['setuptools-scm', 'setuptools>=40.0'],
         install_requires=[
             'Orange3>=3.22.0',
+            'orange-widget-base>=4.14.1',
             'scipy>=1.5.0',
             'pyclipper>=1.2.0',
             'point-annotator~=2.0',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
         use_scm_version=True,
         setup_requires=['setuptools-scm', 'setuptools>=40.0'],
         install_requires=[
-            'Orange3>=3.22.0',
+            'Orange3>=3.28.0',
             'orange-widget-base>=4.14.1',
             'scipy>=1.5.0',
             'pyclipper>=1.2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     pyqtwebengine==5.12.*
     oldest: scikit-learn~=0.22.0
     oldest: orange3==3.28.0
-    oldest: orange-canvas-core==0.1.20
+    oldest: orange-canvas-core==0.1.19
     oldest: orange-widget-base==4.14.1
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     pyqtwebengine==5.12.*
     oldest: scikit-learn~=0.22.0
     oldest: orange3==3.28.0
-    oldest: orange-canvas-core==0.1.19
+    oldest: orange-canvas-core==0.1.20
     oldest: orange-widget-base==4.14.1
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core

--- a/tox.ini
+++ b/tox.ini
@@ -27,12 +27,9 @@ deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
     oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.25.0
-    # Use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.9 ; sys_platform != 'win32'
-    oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
-    oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
-    oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
+    oldest: orange3==3.28.0
+    oldest: orange-canvas-core==0.1.20
+    oldest: orange-widget-base==4.14.1
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests started to fail due to adding summaries in widget base

##### Description of changes
- Removes summaries in marker genes
- Tests still failing but they will be fixed in https://github.com/biolab/orange-widget-base/pull/150.



##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
