### PR TITLE
Annotate Projection: Fix commit invoke

### DIFF
--- a/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
@@ -540,7 +540,7 @@ class OWAnnotateProjection(OWDataProjectionWidget, ConcurrentWidgetMixin):
         if self.task is not None:
             self.cancel()
             self.run_button.setText("Resume")
-            self.commit()
+            self.commit.deferred()
         else:
             self._run()
 
@@ -586,7 +586,7 @@ class OWAnnotateProjection(OWDataProjectionWidget, ConcurrentWidgetMixin):
         if result.clusters.epsilon is not None:
             self.epsilon = result.clusters.epsilon
         self.run_button.setText("Start")
-        self.commit()
+        self.commit.deferred()
 
     def on_exception(self, ex: Exception):
         self.Error.proj_error(ex)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget crashes because the parents commit method is decorated with `gui.deferred`.

##### Description of changes
- change `self.commit()` to `self.commit.deferred()`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
