### PR TITLE
[FIX] Fix compatibility with Python 3.10

### DIFF
--- a/orangecontrib/bioinformatics/kegg/caching.py
+++ b/orangecontrib/bioinformatics/kegg/caching.py
@@ -20,7 +20,7 @@ except ImportError:
 try:
     from UserDict import DictMixin
 except ImportError:
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
 
 
 class Store(object):

--- a/orangecontrib/bioinformatics/ncbi/taxonomy/utils.py
+++ b/orangecontrib/bioinformatics/ncbi/taxonomy/utils.py
@@ -5,7 +5,7 @@ import sqlite3
 import tarfile
 import tempfile
 import textwrap
-import collections
+import collections.abc
 from collections import namedtuple
 from urllib.request import urlopen
 
@@ -136,7 +136,7 @@ _INIT_TABLES = textwrap.dedent(
 )
 
 
-class TaxonomyDB(collections.Mapping):
+class TaxonomyDB(collections.abc.Mapping):
     SCHEMA_VERSION = (0, 0, 1)
 
     def __init__(self, taxdb):

--- a/orangecontrib/bioinformatics/widgets/OWDatabasesUpdate.py
+++ b/orangecontrib/bioinformatics/widgets/OWDatabasesUpdate.py
@@ -103,7 +103,7 @@ class UpdateOptionsItemDelegate(QStyledItemDelegate):
         item = parent.itemFromIndex(index)
         widget = parent.itemWidget(item, 0)
         if widget:
-            size = QSize(size.width(), widget.sizeHint().height() / 2)
+            size = QSize(size.width(), widget.sizeHint().height() // 2)
         return size
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

A number of error when running with python 3.10

##### Description of changes

* Replace use of ABCs from `collections` with `collections.abc`
* Fix an implicit float->int conversion error.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
