### PR TITLE
[FIX] Replace colorpalette and other necessary fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         python-version: [3.7, 3.8]
         tox_env: [py-orange-released]
         experimental: [false]
         name: [Released]
         include:
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
             tox_env: py-orange-released
             experimental: true
@@ -34,7 +34,7 @@ jobs:
             experimental: true
             name: Big Sur
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.7
             tox_env: py-orange-oldest
             experimental: false
@@ -50,7 +50,7 @@ jobs:
             name: Oldest
             experimental: false
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.8
             tox_env: py-orange-latest
             experimental: false

--- a/orangecontrib/bioinformatics/geo/__init__.py
+++ b/orangecontrib/bioinformatics/geo/__init__.py
@@ -83,8 +83,9 @@ def dataset_download(gds_id, samples=None, transpose=False, callback=None):
         _domain = Domain(table.domain.attributes, table.domain.class_vars + (class_var,), table.domain.metas)
 
         table = table.transform(_domain)
-        col, _ = table.get_column_view(class_var)
-        col[:] = [map_class_values[class_val] for class_val in class_values]
+        with table.unlocked(table.Y):
+            col, _ = table.get_column_view(class_var)
+            col[:] = [map_class_values[class_val] for class_val in class_values]
 
     if transpose:
         table = Table.transpose(table, feature_names_column='sample_id', meta_attr_name='genes')
@@ -99,7 +100,8 @@ def dataset_download(gds_id, samples=None, transpose=False, callback=None):
         metas = [var for var in table.domain.metas if var.name != 'Entrez ID'] + [new_var]
         new_domain = Domain(table.domain.attributes, table.domain.class_vars, metas)
         table = table.transform(new_domain)
-        table[:, new_var] = _genes
+        with table.unlocked(table.metas):
+            table[:, new_var] = _genes
 
         # table name is lost after transpose
         table.name = title

--- a/orangecontrib/bioinformatics/ncbi/gene/__init__.py
+++ b/orangecontrib/bioinformatics/ncbi/gene/__init__.py
@@ -220,7 +220,8 @@ class GeneMatcher:
             )
 
             new_data = data_table.transform(new_domain)
-            new_data[:, target_column] = [[str(gene.gene_id) if gene.gene_id else '?'] for gene in self.genes]
+            with new_data.unlocked(new_data.metas):
+                new_data[:, target_column] = [[str(gene.gene_id) if gene.gene_id else '?'] for gene in self.genes]
 
             return new_data
 

--- a/orangecontrib/bioinformatics/ncbi/gene/__init__.py
+++ b/orangecontrib/bioinformatics/ncbi/gene/__init__.py
@@ -14,7 +14,7 @@ from orangecontrib.bioinformatics.widgets.utils.data import TableAnnotation
 
 
 class Gene:
-    """ Representation of gene summary. """
+    """Representation of gene summary."""
 
     __slots__ = gene_info_attributes + ('input_identifier',)
 
@@ -59,7 +59,7 @@ class Gene:
 
 
 class GeneMatcher:
-    """ Gene name matching interface. """
+    """Gene name matching interface."""
 
     def __init__(self, tax_id: str, progress_callback=None, auto_start=True):
         """

--- a/orangecontrib/bioinformatics/preprocess/normalize.py
+++ b/orangecontrib/bioinformatics/preprocess/normalize.py
@@ -9,7 +9,8 @@ from Orange.preprocess.preprocess import Preprocess
 class LogarithmicScale(Preprocess):
     def __call__(self, data) -> Table:
         _data = data.copy()
-        _data.X = np.log2(data.X + 1)
+        with _data.unlocked(_data.X):
+            _data.X = np.log2(data.X + 1)
         return _data
 
 
@@ -25,8 +26,9 @@ class ZScore(Preprocess):
 
     def __call__(self, data) -> Table:
         _data = data.copy()
-        _data.X = zscore(data.X, axis=self.axis)
-        _data.X[np.isnan(_data.X)] = 0
+        with _data.unlocked(_data.X):
+            _data.X = zscore(data.X, axis=self.axis)
+            _data.X[np.isnan(_data.X)] = 0
         return _data
 
 
@@ -70,6 +72,7 @@ class QuantileNormalization(Preprocess):
 
         rank_floor = rank.astype(int)
         rank_ceil = np.ceil(rank).astype(int)
-        _data.X = (mean.take(rank_floor) + mean.take(rank_ceil)) / 2
+        with _data.unlocked(_data.X):
+            _data.X = (mean.take(rank_floor) + mean.take(rank_ceil)) / 2
 
         return _data

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_projection.py
@@ -80,7 +80,8 @@ class TestAnnotateProjection(unittest.TestCase):
         self.assertEqual(float, type(eps))
 
     def test_example_not_clustered(self):
-        self.data[-1] = [23, 23]
+        with self.data.unlocked():
+            self.data[-1] = [23, 23]
         clusters, clusters_meta, eps = annotate_projection(
             self.annotations, self.data, clustering_algorithm=DBSCAN, eps=2, min_samples=3
         )
@@ -190,13 +191,14 @@ class TestAnnotateProjection(unittest.TestCase):
         self.assertGreater(len(clusters_meta["C1"][2]), 0)
 
     def test_socres_with_nan(self):
-        self.annotations.X[0, 0] = np.nan
-        self.annotations.X[1, 1] = np.nan
-        self.annotations.X[1, 2] = np.nan
+        with self.annotations.unlocked():
+            self.annotations.X[0, 0] = np.nan
+            self.annotations.X[1, 1] = np.nan
+            self.annotations.X[1, 2] = np.nan
 
-        self.annotations.X[2, 0] = np.nan
-        self.annotations.X[2, 1] = np.nan
-        self.annotations.X[2, 2] = np.nan
+            self.annotations.X[2, 0] = np.nan
+            self.annotations.X[2, 1] = np.nan
+            self.annotations.X[2, 2] = np.nan
 
         clusters = Table.from_numpy(
             Domain([DiscreteVariable("Cluster", values=["C1", "C3"])]), np.array([[0] * 5 + [1] * 7]).reshape(-1, 1)
@@ -209,7 +211,8 @@ class TestAnnotateProjection(unittest.TestCase):
         self.assertTupleEqual((0.4, 0.4), list(zip(*labels_dict["C1"]))[1])
 
         # check all nans
-        self.annotations.X[:, :] = np.nan
+        with self.annotations.unlocked():
+            self.annotations.X[:, :] = np.nan
         labels_dict, labels_items = assign_labels(clusters, self.annotations, 3)
         transformed_labels = list(map(labels_items.domain.attributes[0].repr_val, labels_items.X[:, 0]))
         self.assertListEqual(['?'] * len(self.annotations), transformed_labels)

--- a/orangecontrib/bioinformatics/tests/annotation/test_annotate_samples.py
+++ b/orangecontrib/bioinformatics/tests/annotation/test_annotate_samples.py
@@ -60,7 +60,8 @@ class TestAnnotateSamples(unittest.TestCase):
 
     @dense_sparse
     def test_mann_whitney_test(self, array):
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         d = self.annotator.mann_whitney_test(self.data)
         self.assertEqual(type(d), Table)
         self.assertTupleEqual(self.data.X.shape, d.X.shape)
@@ -79,7 +80,8 @@ class TestAnnotateSamples(unittest.TestCase):
 
     @dense_sparse
     def test_artificial_data(self, array):
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, self.markers)
 
         self.assertEqual(type(annotations), Table)
@@ -109,8 +111,8 @@ class TestAnnotateSamples(unittest.TestCase):
             ["Type 3", "313"],
         ]
         markers = Table(m_domain, np.empty((len(m_data), 0)), None, m_data)
-
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, markers)
 
         self.assertEqual(type(annotations), Table)
@@ -132,7 +134,8 @@ class TestAnnotateSamples(unittest.TestCase):
         """
         Test annotations with hypergeom.sf
         """
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, self.markers, p_value_fun=PFUN_HYPERGEOMETRIC)
 
         self.assertEqual(type(annotations), Table)
@@ -144,9 +147,10 @@ class TestAnnotateSamples(unittest.TestCase):
 
     @dense_sparse
     def test_two_example(self, array):
-        self.data = self.data[:2]
+        self.data = self.data[:2].copy()
 
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, self.markers)
 
         self.assertEqual(type(annotations), Table)
@@ -154,8 +158,10 @@ class TestAnnotateSamples(unittest.TestCase):
 
     @dense_sparse
     def test_markers_without_entrez_id(self, array):
-        self.markers[1, "Entrez ID"] = "?"
-        self.data.X = array(self.data.X)
+        with self.markers.unlocked():
+            self.markers[1, "Entrez ID"] = "?"
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, self.markers, return_nonzero_annotations=False)
 
         self.assertEqual(type(annotations), Table)
@@ -167,7 +173,8 @@ class TestAnnotateSamples(unittest.TestCase):
 
     @dense_sparse
     def test_select_attributes(self, array):
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         z = self.annotator.mann_whitney_test(self.data)
 
         self.assertEqual(z.X.shape, self.data.X.shape)
@@ -193,7 +200,8 @@ class TestAnnotateSamples(unittest.TestCase):
             {"211", "212", "213", "214"},
         ]
         exp_ann = np.array([[1, 0], [1 / 2, 1 / 4], [1 / 4, 1 / 2], [0, 1]])
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations, fdrs = self.annotator.assign_annotations(z_table, self.markers, self.data[:4])
 
         self.assertEqual(len(attrs), len(annotations))
@@ -213,7 +221,8 @@ class TestAnnotateSamples(unittest.TestCase):
         # https://github.com/pandas-dev/pandas/issues/28992
         if isinstance(array, functools.partial):
             return
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, self.markers, scoring=SCORING_EXP_RATIO)
 
         self.assertEqual(type(annotations), Table)
@@ -259,7 +268,8 @@ class TestAnnotateSamples(unittest.TestCase):
         for i, att in enumerate(self.data.domain.attributes):
             att.attributes["Entrez ID"] = int(att.attributes["Entrez ID"])
 
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, self.markers)
 
         self.assertEqual(type(annotations), Table)
@@ -288,7 +298,8 @@ class TestAnnotateSamples(unittest.TestCase):
                 )
             ),
         )
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, markers)
 
         self.assertEqual(type(annotations), Table)
@@ -317,7 +328,8 @@ class TestAnnotateSamples(unittest.TestCase):
                 )
             ),
         )
-        self.data.X = array(self.data.X)
+        with self.data.unlocked(self.data.X):
+            self.data.X = array(self.data.X)
         annotations = self.annotate_samples(self.data, markers)
 
         self.assertEqual(type(annotations), Table)

--- a/orangecontrib/bioinformatics/tests/ncbi/test_taxonomy.py
+++ b/orangecontrib/bioinformatics/tests/ncbi/test_taxonomy.py
@@ -38,7 +38,7 @@ class TestTaxonomy(unittest.TestCase):
 
         self.assertRaises(taxonomy.utils.UnknownSpeciesIdentifier, self.tax_obj.get_entry, 'unknown_tax')
 
-        self.assertTrue(('man', 'common name') in self.tax_obj.other_names(self.human))
+        self.assertTrue(('human', 'genbank common name') in self.tax_obj.other_names(self.human))
         self.assertEqual(self.tax_obj.rank(self.human), 'species')
         self.assertEqual(self.tax_obj.parent(self.human), '9605')
 

--- a/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
@@ -19,7 +19,7 @@ from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.utils.concurrent import TaskState, ConcurrentWidgetMixin
 from Orange.widgets.utils.itemmodels import DomainModel
-from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
+from Orange.widgets.utils.colorpalettes import LimitedDiscretePalette
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.utils.widget import OWDataProjectionWidget
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
@@ -786,7 +786,7 @@ class OWAnnotateProjection(OWDataProjectionWidget, ConcurrentWidgetMixin):
         return (
             self.clusters.table.domain["Clusters"].palette
             if hasattr(self.clusters.table.domain["Clusters"], "palette")
-            else ColorPaletteGenerator(number_of_colors=len(colors), rgb_colors=colors)
+            else LimitedDiscretePalette(number_of_colors=len(colors))
         )
 
     def get_cluster_hulls(self):

--- a/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
@@ -876,8 +876,9 @@ class OWAnnotateProjection(OWDataProjectionWidget, ConcurrentWidgetMixin):
         metas = chain(domain.metas, [source_attr])
         domain = Domain(domain.attributes, domain.class_vars, metas)
         data = data.transform(domain)
-        data.metas[: len(self.reference_data), -1] = 0
-        data.metas[len(self.reference_data) :, -1] = 1
+        with data.unlocked(data.metas):
+            data.metas[: len(self.reference_data), -1] = 0
+            data.metas[len(self.reference_data) :, -1] = 1
         return data
 
     def _get_send_report_caption(self):

--- a/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
@@ -831,9 +831,10 @@ class OWAnnotateProjection(OWDataProjectionWidget, ConcurrentWidgetMixin):
 
         def get_augmented_data(table, scores_x, clusters_x):
             new_table = table.transform(domain)
-            if scores_x is not None:
-                new_table.metas[:, :n_sco] = scores_x
-            new_table.metas[:, n_sco:n_clu] = clusters_x
+            with new_table.unlocked(new_table.metas):
+                if scores_x is not None:
+                    new_table.metas[:, :n_sco] = scores_x
+                new_table.metas[:, n_sco:n_clu] = clusters_x
             return new_table
 
         n_sco = self.scores.table.X.shape[1]

--- a/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
+++ b/orangecontrib/bioinformatics/widgets/OWAnnotateProjection.py
@@ -463,13 +463,16 @@ class OWAnnotateProjection(OWDataProjectionWidget, ConcurrentWidgetMixin):
 
     @property
     def effective_variables(self):
-        return self.reference_data.domain.attributes
+        attr_x, attr_y = self.attr_x, self.attr_y
+        if attr_x and attr_y:
+            if attr_x == attr_y:
+                return [attr_x]
+            return [attr_x, attr_y]
+        return []
 
     @property
     def effective_data(self):
-        return self.reference_data.transform(
-            Domain(self.effective_variables, self.reference_data.domain.class_vars, self.reference_data.domain.metas)
-        )
+        return self.reference_data.transform(Domain(self.effective_variables))
 
     @property
     def can_annotate(self):

--- a/orangecontrib/bioinformatics/widgets/OWHomologs.py
+++ b/orangecontrib/bioinformatics/widgets/OWHomologs.py
@@ -199,10 +199,11 @@ class OWHomologs(widget.OWWidget):
                 )
 
                 table = self.data.transform(domain)
-                col, _ = table.get_column_view(homolog)
-                col[:] = [g.symbol if g else "?" for g in homologs]
-                col, _ = table.get_column_view(homolog_id)
-                col[:] = [g.gene_id if g else "?" for g in homologs]
+                with table.unlocked(table.metas):
+                    col, _ = table.get_column_view(homolog)
+                    col[:] = [g.symbol if g else "?" for g in homologs]
+                    col, _ = table.get_column_view(homolog_id)
+                    col[:] = [g.gene_id if g else "?" for g in homologs]
 
                 # note: filter out rows with unknown homologs
                 table = table[table.get_column_view(homolog_id)[0] != "?"]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
         use_scm_version=True,
         setup_requires=['setuptools-scm', 'setuptools>=40.0'],
         install_requires=[
-            'Orange3>=3.28.0',
+            'Orange3>=3.31.0',
             'orange-widget-base>=4.14.1',
             'scipy>=1.5.0',
             'pyclipper>=1.2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,10 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.28.0
-    oldest: orange-canvas-core==0.1.20
-    oldest: orange-widget-base==4.14.1
+    oldest: scikit-learn~=0.23.0
+    oldest: orange3==3.31.0
+    oldest: orange-canvas-core==0.1.24
+    oldest: orange-widget-base==4.16.1
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,9 @@ deps =
     oldest: orange3==3.28.0
     oldest: orange-canvas-core==0.1.20
     oldest: orange-widget-base==4.14.1
-    latest: git+git://github.com/biolab/orange3.git#egg=orange3
-    latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
-    latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
+    latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
+    latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
+    latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
 commands_pre =
     # Verify installed packages have compatible dependencies
     pip check


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Annotator use colorpalette which is deprecated https://github.com/biolab/orange3/pull/6135
Because of changes in Orange (mostly Table lock), some widgets/tests do not work.

##### Description of changes
Use colorpalettes module instead
Necessary fixes for widgets/tests to work:
- handle table locking where necessary
- changing `effective_data` to match other widgets (and I think it is now more correct than before). It was necessary to fix it due to a failing test caused by the change in core Orange. If I understand effective_data correctly, are those data currently plotted as x and y, and if they do not change, replot is unnecessary.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
