### PR TITLE
[FIX] QtCore.Qt.ItemIsTristate is deprecated. Use ItemIsUserTristate instead

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
     - id: black
       language_version: python3
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
     - id: isort
       language_version: python3
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
       language_version: python3

--- a/orangecontrib/bioinformatics/widgets/components/gene_set_selection.py
+++ b/orangecontrib/bioinformatics/widgets/components/gene_set_selection.py
@@ -135,7 +135,7 @@ class GeneSetSelection(OWComponent, QObject):
             parent.setCheckState(0, Qt.Unchecked)
             parent.setExpanded(True)
             parent.hierarchy = (domain,)
-            parent.setFlags(parent.flags() | Qt.ItemIsTristate)
+            parent.setFlags(parent.flags() | Qt.ItemIsUserTristate)
 
             for sub_domain in sub_domains:
                 if sub_domain is None:
@@ -159,7 +159,7 @@ class GeneSetSelection(OWComponent, QObject):
         self.selection_changed.emit()
 
     def _get_selection(self) -> List[Tuple[str, ...]]:
-        """ Return a list of selected hierarchies """
+        """Return a list of selected hierarchies"""
         iterator = QTreeWidgetItemIterator(self.hierarchy_tree_widget, flags=QTreeWidgetItemIterator.Checked)
 
         selected: List[Tuple[str, ...]] = []

--- a/orangecontrib/bioinformatics/widgets/utils/gui/gene_sets.py
+++ b/orangecontrib/bioinformatics/widgets/utils/gui/gene_sets.py
@@ -74,7 +74,7 @@ class GeneSetsSelection(QWidget):
 
         for gene_set in gene_sets:
             g_sets = load_gene_sets(gene_set, tax_id)
-            self.gs_object.update([g_set for g_set in g_sets])
+            self.gs_object.update(list(g_sets))
 
         self.set_selected_hierarchies()
 
@@ -108,7 +108,7 @@ class GeneSetsSelection(QWidget):
             item.hierarchy = key
 
             if value:
-                item.setFlags(item.flags() | Qt.ItemIsTristate)
+                item.setFlags(item.flags() | Qt.ItemIsUserTristate)
                 self.set_hierarchy_model(item, value)
             else:
                 if item.parent():
@@ -118,8 +118,7 @@ class GeneSetsSelection(QWidget):
                 item.hierarchy = (key,)
 
     def get_hierarchies(self, **kwargs):
-        """ return selected hierarchy
-        """
+        """return selected hierarchy"""
         only_selected = kwargs.get('only_selected', None)
 
         sets_to_display = []


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
