### PR TITLE
[FIX] annotate_projection: Delaunay attribute 'vertices' deprecated in favour of 'simplices'

### DIFF
--- a/orangecontrib/bioinformatics/annotation/annotate_projection.py
+++ b/orangecontrib/bioinformatics/annotation/annotate_projection.py
@@ -416,7 +416,7 @@ def compute_concave_hulls(coordinates, clusters, epsilon):
         edges = set()
         # loop over triangles:
         # ia, ib, ic = indices of corner points of the triangle
-        for ia, ib, ic in tri.vertices:
+        for ia, ib, ic in tri.simplices:
             pa = pts[ia]
             pb = pts[ib]
             pc = pts[ic]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
         install_requires=[
             'Orange3>=3.31.0',
             'orange-widget-base>=4.14.1',
-            'scipy>=1.5.0',
+            'scipy>=1.11.0',
             'pyclipper>=1.2.0',
             'point-annotator~=2.0',
             'requests',


### PR DESCRIPTION
##### Issue

Delaunay attribute vertices was deprecated since Scipy version 0.12.0 in favour of simplices and it was finally removed in version 1.11.0.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
