### PR TITLE
[FIX] dictyExpress: Time as ContinuousVariable

### DIFF
--- a/orangecontrib/bioinformatics/resolwe/utils.py
+++ b/orangecontrib/bioinformatics/resolwe/utils.py
@@ -59,9 +59,11 @@ def etc_to_table(etc_json, transpose=False):
         )
 
         old_domain = orange_table.domain
-        new_domain = Domain(old_domain.attributes,
-                            old_domain.class_vars,
-                            [ContinuousVariable(var.name) for var in old_domain.metas])
+        new_domain = Domain(
+            old_domain.attributes,
+            old_domain.class_vars,
+            [ContinuousVariable(var.name) for var in old_domain.metas],
+        )
 
         time_as_floats = orange_table.get_column('Time').astype(int).reshape(-1, 1)
         orange_table = orange_table.transform(new_domain)

--- a/orangecontrib/bioinformatics/resolwe/utils.py
+++ b/orangecontrib/bioinformatics/resolwe/utils.py
@@ -58,12 +58,14 @@ def etc_to_table(etc_json, transpose=False):
             remove_redundant_inst=True,
         )
 
-        orange_table.domain = Domain(
-            orange_table.domain.attributes,
-            orange_table.domain.class_vars,
-            [ContinuousVariable('Time')],
-        )
+        old_domain = orange_table.domain
+        new_domain = Domain(old_domain.attributes,
+                            old_domain.class_vars,
+                            [ContinuousVariable(var.name) for var in old_domain.metas])
 
+        time_as_floats = orange_table.get_column('Time').astype(int).reshape(-1, 1)
+        orange_table = orange_table.transform(new_domain)
+        orange_table[:, new_domain['Time']] = time_as_floats
     return orange_table
 
 

--- a/orangecontrib/bioinformatics/resolwe/utils.py
+++ b/orangecontrib/bioinformatics/resolwe/utils.py
@@ -58,6 +58,12 @@ def etc_to_table(etc_json, transpose=False):
             remove_redundant_inst=True,
         )
 
+        orange_table.domain = Domain(
+            orange_table.domain.attributes,
+            orange_table.domain.class_vars,
+            [ContinuousVariable('Time')],
+        )
+
     return orange_table
 
 

--- a/orangecontrib/bioinformatics/widgets/OWdictyExpress.py
+++ b/orangecontrib/bioinformatics/widgets/OWdictyExpress.py
@@ -349,7 +349,7 @@ class CustomTreeItem(QTreeWidgetItem):
         for index, label in enumerate(Labels):
             if index > 0:
                 try:
-                    if isinstance(type(row[label[0]]["value"]), list):
+                    if isinstance(row[label[0]]["value"], list):
                         self.setText(index, row[label[0]]["value"][0]["name"])
                     else:
                         self.setText(index, row[label[0]]["value"])


### PR DESCRIPTION
##### Issue
When trying to use dictyExpress as a data source to compare the new data with published data, there is an error. The problem seems to be that the Time column is a String Variable and therefore its PCA cannot be applied to newer data. Editing the domain (so that Time is numeric variable) doesn't seem to fix the issue. Here is a screenshot of the problem.

![screenshot1](https://github.com/biolab/orange3-bioinformatics/assets/115463806/4b9803cf-e9bc-4b0d-abe6-e002c62819d3)

##### Description of changes

I propose changing the code so that Time is set as a ContinuousVariable. I also fixed the bug that prevented the dictyExpress from loading (if isinstance(type(row[label[0]]["value"]), list): --> if isinstance(row[label[0]]["value"], list):).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
