### PR TITLE
GSEA: sorting and organism bug

### DIFF
--- a/orangecontrib/bioinformatics/widgets/OWGeneSetEnrichment.py
+++ b/orangecontrib/bioinformatics/widgets/OWGeneSetEnrichment.py
@@ -478,7 +478,7 @@ class OWGeneSets(OWWidget, ConcurrentWidgetMixin):
         if input_data:
             self.input_data = input_data
             self.gene_info = GeneInfo(self.tax_id)
-            self.gs_selection_component.initialize(self.tax_id)
+            self.gs_selection_component.set_selected_organism_by_tax_id(self.tax_id)
 
     @Inputs.custom_gene_sets
     def handle_custom_gene_sets_input(self, custom_data):

--- a/orangecontrib/bioinformatics/widgets/utils/gui/__init__.py
+++ b/orangecontrib/bioinformatics/widgets/utils/gui/__init__.py
@@ -66,7 +66,7 @@ class FilterProxyModel(QSortFilterProxyModel):
         self.__filters = []
 
     def sort(self, *args, **kwargs):
-        return self.sourceModel().sort(*args, **kwargs)
+        super().sort(*args, **kwargs)
 
     def reset_filters(self):
         self.__filters = []


### PR DESCRIPTION
##### Issue
Fixes #332 

Also fixes sorting that did not work when you clicked on the column in Gene Set Enrichment widget.


##### Description of changes
I changed the code so that it sorts the proxy model, not the source model. I also changed the code so that the widget loads the gene sets based on the organism of the input data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
