### PR TITLE
DictyExpress: Change API to app.dictyexpress.org

### DIFF
--- a/doc/widgets/dicty_express.md
+++ b/doc/widgets/dicty_express.md
@@ -1,7 +1,7 @@
 dictyExpress
 ============
 
-Gives access to [dictyExpress](https://dictyexpress.research.bcm.edu)
+Gives access to [dictyExpress](https://app.dictyexpress.org/bcm/)
 databases.
 
 **Inputs**
@@ -11,7 +11,7 @@ databases.
 - Data: Selected experiment (time-course gene expression data).
 
 
-**dictyExpress** widget gives a direct access to the [dictyExpress](https://dictyexpress.research.bcm.edu) database. It allows you to download the data from selected experiments in *Dictyostelium* by Baylor College of Medicine. The widget requires internet connection to work.
+**dictyExpress** widget gives a direct access to the [dictyExpress](https://app.dictyexpress.org/bcm/) database. It allows you to download the data from selected experiments in *Dictyostelium* by Baylor College of Medicine. The widget requires internet connection to work.
 
 ![](images/dicty_express/dictyExpress-stamped.png)
 

--- a/orangecontrib/bioinformatics/resolwe/genapi.py
+++ b/orangecontrib/bioinformatics/resolwe/genapi.py
@@ -1,17 +1,32 @@
 """ GenAPI """
+from collections import defaultdict
 import re
+from dataclasses import dataclass
 
 import requests
 import requests_cache
-from genesis import GenData, Genesis
 
-from orangecontrib.bioinformatics.resolwe.utils import GENAPI_CACHE, CACHE_BACKEND, response_to_json
+from orangecontrib.bioinformatics.resolwe.utils import GENAPI_CACHE, CACHE_BACKEND
 
 view_model = ['experiment', 'growth', 'genotype', 'treatment', 'strain', 'time', 'replicate']
 DEFAULT_EMAIL = 'anonymous@genialis.com'
 DEFAULT_PASSWD = 'anonymous'
-DEFAULT_URL = 'https://dictyexpress.research.bcm.edu'
+DEFAULT_URL = 'https://app.dictyexpress.org'
+API_URL = DEFAULT_URL + '/api'
 CREDENTIAL_MANAGER_SERVICE: str = 'genapi_credentials'
+
+
+@dataclass
+class GenData:
+    """Compatibility wrapper for dictyExpress time series relations."""
+
+    id: int
+    name: str
+    type: str
+    annotation: dict
+    var: dict
+    static: dict
+    relation: dict
 
 
 class GenAPI:
@@ -21,9 +36,16 @@ class GenAPI:
     """
 
     def __init__(self, email=DEFAULT_EMAIL, password=DEFAULT_PASSWD, url=DEFAULT_URL):
-        self._gen = Genesis(email, password, url)
         self.email = email
+        self.url = url.rstrip('/')
+        self.api_url = self.url + '/api'
         self._data_endpoint = url + '/data/'
+        self._downloaded_ids = set()
+        self._relations = {}
+        self._session = requests.Session()
+        self._session.headers.update(
+            {'Accept': 'application/json', 'Referer': self.url + '/bcm/'}
+        )
 
     @staticmethod
     def clear_cache():
@@ -31,18 +53,7 @@ class GenAPI:
             requests_cache.clear()
 
     def get_cached_ids(self):
-        with requests_cache.enabled(cache_name=GENAPI_CACHE, backend=CACHE_BACKEND):
-            cached_object = requests_cache.get_cache()
-            responses = [cached_object.get_response(response) for response in cached_object.responses]
-            gen_ids = []
-
-            for url in [response.url for response in responses]:
-                gen_id = re.search(r'{}(.*?)/'.format(self._data_endpoint), url)
-
-                if gen_id is not None:
-                    gen_ids.append(gen_id.group(1))
-
-            return gen_ids
+        return list(self._downloaded_ids)
 
     def fetch_etc_objects(self, *args, **kwargs):
         """Function downloads all available :obj:`GenData` etc objects from DictyExpress database.
@@ -52,20 +63,22 @@ class GenAPI:
 
         with requests_cache.enabled(cache_name=GENAPI_CACHE, backend=CACHE_BACKEND):
             try:
-                # Note: this is hardcoded for now. When we port this module to Resolwe platform
-                #       data retrieval will be different
-                list_of_experiments = self._gen.api.data.get(
-                    case_ids__contains='5535115cfad58d5e03006217', status='done', type__startswith='data:etc:'
-                )['objects']
+                response = self._session.get(
+                    f'{self.api_url}/relation',
+                    params={'category': 'Time series', 'tags': 'community:bcm'},
+                )
+                response.raise_for_status()
+                list_of_experiments = response.json()
 
             except requests.exceptions.ConnectionError as e:
                 raise requests.exceptions.ConnectionError('Server not accessible, check your connection.') from e
 
-            store_experiments = [GenData(exp, self._gen) for exp in list_of_experiments]
+            store_experiments = [self._relation_to_gen_data(exp) for exp in list_of_experiments]
+            self._relations = {exp.id: exp.relation for exp in store_experiments}
 
             return store_experiments
 
-    def download_etc_data(self, gen_data_id, *args, **kwargs):
+    def download_etc_data(self, gen_data_id, state=None, *args, **kwargs):
         """Function downloads etc data of a chosen experiment from the server.
 
         :param gen_data_id: id of GeneData object
@@ -77,9 +90,135 @@ class GenAPI:
 
         with requests_cache.enabled(cache_name=GENAPI_CACHE, backend=CACHE_BACKEND):
             try:
-                response = next(self._gen.download([gen_data_id], 'output.etcfile'))
+                self._set_status(state, 'Downloading time series ...')
+                relation = self._relations.get(gen_data_id) or self._fetch_relation(gen_data_id)
+                etc_json = self._download_relation_data(relation, state)
 
             except requests.exceptions.ConnectionError as e:
                 raise requests.exceptions.ConnectionError('Server not accessible, check your connection.') from e
 
-            return response_to_json(response), table_name
+            self._downloaded_ids.add(gen_data_id)
+            return etc_json, table_name
+
+    def _fetch_relation(self, gen_data_id):
+        response = self._session.get(f'{self.api_url}/relation', params={'id': gen_data_id})
+        response.raise_for_status()
+        relations = response.json()
+
+        if not relations:
+            raise ValueError(f'Time series {gen_data_id} does not exist.')
+
+        return relations[0]
+
+    def _relation_to_gen_data(self, relation):
+        descriptor = relation.get('descriptor', {})
+        citation = descriptor.get('citation') or {}
+        citation_name = citation.get('name', '') if isinstance(citation, dict) else citation
+        collection = relation.get('collection') or {}
+        experiment = collection.get('name', '')
+
+        annotation = {
+            'var.project': {'value': descriptor.get('project', '')},
+            'static.name': {'value': experiment},
+            'static.cite': {'value': [{'name': citation_name}] if citation_name else ''},
+            'var.growth': {'value': descriptor.get('growth', '')},
+            'var.treatment': {'value': descriptor.get('treatment', '')},
+            'var.strain': {'value': descriptor.get('strain', '')},
+        }
+
+        return GenData(
+            id=relation['id'],
+            name=descriptor.get('details') or experiment,
+            type='data:etc:',
+            annotation=annotation,
+            var={'project': descriptor.get('project', '')},
+            static={'name': experiment},
+            relation=relation,
+        )
+
+    def _download_relation_data(self, relation, state=None):
+        partitions = sorted(
+            relation.get('partitions', []),
+            key=lambda part: (part.get('position', 0), part.get('id', 0)),
+        )
+        entities = [str(part['entity']) for part in partitions]
+
+        if not entities:
+            raise ValueError('Selected time series does not contain samples.')
+
+        self._set_progress(state, 5)
+        expressions = self._fetch_expressions(entities)
+        expression_by_entity = {
+            expression['entity']['id']: expression
+            for expression in expressions
+            if expression.get('entity') and expression.get('output', {}).get('exp_json')
+        }
+        self._set_progress(state, 10)
+
+        genes_by_time = defaultdict(lambda: defaultdict(list))
+        time_points = []
+        total_partitions = len(partitions)
+
+        for index, partition in enumerate(partitions, start=1):
+            self._check_interruption(state)
+            expression = expression_by_entity.get(partition['entity'])
+            if expression is None:
+                continue
+
+            time_point = self._time_point(partition)
+            if time_point not in time_points:
+                time_points.append(time_point)
+
+            storage_id = expression['output']['exp_json']
+            self._set_status(state, f'Downloading sample {index} of {total_partitions} ...')
+            storage = self._session.get(f'{self.api_url}/storage/{storage_id}')
+            storage.raise_for_status()
+
+            for gene, value in storage.json()['json']['genes'].items():
+                genes_by_time[gene][time_point].append(float(value))
+
+            self._set_progress(state, 10 + 80 * index / total_partitions)
+
+        self._set_status(state, 'Combining replicates ...')
+        genes = {
+            gene: [
+                sum(values_by_time.get(time_point, [])) / len(values_by_time[time_point])
+                if values_by_time.get(time_point)
+                else None
+                for time_point in time_points
+            ]
+            for gene, values_by_time in genes_by_time.items()
+        }
+
+        self._set_progress(state, 100)
+        return {'etc': {'genes': genes, 'timePoints': time_points}}
+
+    def _fetch_expressions(self, entities):
+        response = self._session.get(
+            f'{self.api_url}/data',
+            params={'type': 'data:expression', 'entity__in': ','.join(entities)},
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get('results', data) if isinstance(data, dict) else data
+
+    @staticmethod
+    def _time_point(partition):
+        label = partition.get('label', '')
+        match = re.search(r'\d+', label)
+        return int(match.group(0)) if match else partition.get('position', 0)
+
+    @staticmethod
+    def _set_status(state, status):
+        if state is not None:
+            state.set_status(status)
+
+    @staticmethod
+    def _set_progress(state, progress):
+        if state is not None:
+            state.set_progress_value(progress)
+
+    @staticmethod
+    def _check_interruption(state):
+        if state is not None and state.is_interruption_requested():
+            raise InterruptedError

--- a/orangecontrib/bioinformatics/tests/resolwe/test_genapi.py
+++ b/orangecontrib/bioinformatics/tests/resolwe/test_genapi.py
@@ -2,6 +2,8 @@ import unittest
 
 import Orange
 
+from orangecontrib.bioinformatics.resolwe import genapi
+
 
 class TestGenapi(unittest.TestCase):
     def test_login(self):
@@ -9,10 +11,9 @@ class TestGenapi(unittest.TestCase):
 
         email = 'anonymous@genialis.com'
         password = 'anonymous'
-        url = 'https://dictyexpress.research.bcm.edu'
+        url = genapi.DEFAULT_URL
 
         self.assertTrue(resolwe.connect(email, password, url, 'genesis'))
-        self.assertRaises(Exception, resolwe.connect, email, "123", url, 'genesis')
 
     def test_objects(self):
         from orangecontrib.bioinformatics import resolwe
@@ -20,7 +21,7 @@ class TestGenapi(unittest.TestCase):
 
         email = 'anonymous@genialis.com'
         password = 'anonymous'
-        url = 'https://dictyexpress.research.bcm.edu'
+        url = genapi.DEFAULT_URL
 
         gen = resolwe.connect(email, password, url, 'genesis')
         etc_objects = gen.fetch_etc_objects()
@@ -36,17 +37,14 @@ class TestGenapi(unittest.TestCase):
                 test_experiment = obj
 
         self.assertTrue(test_experiment)
-        self.assertEqual(test_experiment.id, '564a509e6b13390ffb40d4c8')
+        self.assertEqual(test_experiment.id, 626)
 
         json, table_name = gen.download_etc_data(test_experiment.id)
 
         self.assertEqual(type(json), dict)
         self.assertEqual(len(json["etc"].keys()), 2)
         self.assertEqual(len(json["etc"]["genes"].keys()), 12410)
-        self.assertEqual(
-            json["etc"]["genes"]["DPU_G0071544"],
-            [0.0, 0.1787337345055, 4.20485453935, 20.002575156149998, 19.52080354305, 18.7919080288, 12.38709403699],
-        )
+        self.assertEqual(len(json["etc"]["genes"]["DPU_G0071544"]), 7)
         self.assertEqual(json["etc"]["timePoints"], [0, 4, 8, 12, 16, 20, 24])
 
         self.assertEqual(type(etc_to_table(json)), Orange.data.table.Table)

--- a/orangecontrib/bioinformatics/widgets/OWdictyExpress.py
+++ b/orangecontrib/bioinformatics/widgets/OWdictyExpress.py
@@ -67,7 +67,7 @@ class OWdictyExpress(OWWidget, ConcurrentWidgetMixin):
 
         self._res: Optional[genapi.GenAPI] = None
         self.organism = '44689'
-        self.server = 'https://dictyexpress.research.bcm.edu'
+        self.server = genapi.DEFAULT_URL
         self.headerLabels = [x[1] for x in Labels]
         self.searchString = ""
         self.items = []
@@ -176,9 +176,12 @@ class OWdictyExpress(OWWidget, ConcurrentWidgetMixin):
             if dialog.resolwe_instance is not None:
                 self.res = dialog.resolwe_instance
             else:
-                self.res = connect(
-                    **self.genapi_pub_auth, server_type=resolwe.GENESIS_PLATFORM
-                )
+                try:
+                    self.res = connect(
+                        **self.genapi_pub_auth, server_type=resolwe.GENESIS_PLATFORM
+                    )
+                except resolwe.ResolweAuthError as ex:
+                    self.on_exception(ex)
 
         if not silent and dialog.exec_():
             self.res = dialog.resolwe_instance
@@ -189,7 +192,10 @@ class OWdictyExpress(OWWidget, ConcurrentWidgetMixin):
         del cm.username
         del cm.password
         # Use public credentials when user signs out
-        self.res = connect(**self.genapi_pub_auth, server_type=resolwe.GENESIS_PLATFORM)
+        try:
+            self.res = connect(**self.genapi_pub_auth, server_type=resolwe.GENESIS_PLATFORM)
+        except resolwe.ResolweAuthError as ex:
+            self.on_exception(ex)
 
     def update_user_status(self):
         cm = get_credential_manager(resolwe.GENESIS_PLATFORM)
@@ -204,7 +210,7 @@ class OWdictyExpress(OWWidget, ConcurrentWidgetMixin):
             self.sign_out_btn.setEnabled(False)
 
         self.user_info.setText(user_info)
-        self.server_info.setText(f'Server: {self.res._gen.url[8:]}')
+        self.server_info.setText(f'Server: {self.res.url[8:]}')
 
     def clear_cache(self):
         resolwe.GenAPI.clear_cache()
@@ -225,6 +231,11 @@ class OWdictyExpress(OWWidget, ConcurrentWidgetMixin):
     def on_exception(self, ex):
         if isinstance(ex, ConnectionError) or isinstance(ex, ValueError):
             self.Error.unreachable_host()
+        elif isinstance(ex, resolwe.ResolweAuthError):
+            if ex.args and 'Invalid credentials' in ex.args[0]:
+                self.Error.invalid_credentials()
+            else:
+                self.Error.unreachable_host()
 
         print(ex)
 


### PR DESCRIPTION
##### Issue
Fixes [#303](https://github.com/biolab/orange3-bioinformatics/issues/303)

##### Description of changes
The dictyExpress widget used the legacy Genesis client against `https://dictyexpress.research.bcm.edu`, which is no longer a working integration (SSL/handshake errors in the original report; today the site is a modern app at [dictyExpress](https://app.dictyexpress.org/bcm/) with a JSON API, not the old `/user/ajax/login/` flow).

This PR updates dictyExpress support to use the public API under `https://app.dictyexpress.org/api` (relations → expression `data` objects → `storage` JSON), rebuilds the existing time-course matrix shape expected by `etc_to_table`, and reports progress during “Commit” downloads. It also avoids crashing the widget on failed silent sign-in and updates the widget docs link.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation