### PR TITLE
[FIX] Homologs: Fix an error when input has unknown gene id

### DIFF
--- a/orangecontrib/bioinformatics/tests/widgets/test_OWHomologs.py
+++ b/orangecontrib/bioinformatics/tests/widgets/test_OWHomologs.py
@@ -79,6 +79,22 @@ class TestOWMHomologs(WidgetTest):
 
         self.assertListEqual(mouse_ids, self.expected_results)
 
+    def test_unknown_gene_id(self):
+        self.widget.auto_commit = False
+        self.widget.target_organism_change(self.widget.taxonomy_ids.index("10090"))
+
+        data = self.genes_rows.copy()
+        with data.unlocked():
+            data.metas[1, 1] = "?"
+        self.send_signal(self.widget.Inputs.data, data)
+        self.widget.auto_commit = True
+        self.widget.commit()
+
+        out_data = self.get_output(self.widget.Outputs.genes, self.widget)
+        self.assertEqual(len(out_data), len(data) - 1)
+        mouse_ids = list(out_data.get_column(HOMOLOG_ID))
+        self.assertListEqual(mouse_ids, [self.expected_results[0], *self.expected_results[2:]])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/orangecontrib/bioinformatics/widgets/OWHomologs.py
+++ b/orangecontrib/bioinformatics/widgets/OWHomologs.py
@@ -159,7 +159,7 @@ class OWHomologs(widget.OWWidget):
         gm = GeneMatcher(self.source_tax)
         gm.genes = genes
 
-        homologs = [g.homolog_gene(taxonomy_id=self.target_tax) for g in gm.genes]
+        homologs = [g.homolog_gene(taxonomy_id=self.target_tax) if g.gene_id else None for g in gm.genes]
         homologs = load_gene_summary(self.target_tax, homologs)
 
         return homologs

--- a/orangecontrib/bioinformatics/widgets/OWHomologs.py
+++ b/orangecontrib/bioinformatics/widgets/OWHomologs.py
@@ -1,4 +1,3 @@
-""" OWMarkerGenes """
 import sys
 from typing import List, Union, Optional
 
@@ -45,6 +44,7 @@ class OWHomologs(widget.OWWidget):
         mising_gene_id_attribute = Msg(ERROR_ON_MISSING_ANNOTATION)
 
     want_main_area = False
+    resizing_enabled = False
 
     auto_commit = Setting(True)
     selected_organism: str = Setting('')
@@ -73,9 +73,6 @@ class OWHomologs(widget.OWWidget):
         gui.auto_commit(
             self.controlArea, self, "auto_commit", "Commit", "Commit Automatically"
         )
-
-        self.info.set_input_summary("0")
-        self.info.set_output_summary("0")
 
     @Inputs.data
     def set_data(self, data: Table) -> None:
@@ -110,8 +107,6 @@ class OWHomologs(widget.OWWidget):
                     self.data = None
                     return
         else:
-            self.info.set_input_summary("0")
-            self.info.set_output_summary("0")
             self.info_gene.clear()
             self.info_gene_type.setText("No data on input.")
             self.Outputs.genes.send(None)
@@ -151,8 +146,6 @@ class OWHomologs(widget.OWWidget):
             else len(data)
         )
         self.info_gene.setText(f"Number of genes: {data_len}")
-        self.info.set_input_summary(f"{data_len}")
-
         self.commit()
 
     def find_homologs(self, genes: List[Union[str, Gene]]) -> List[Optional[Gene]]:
@@ -228,14 +221,9 @@ class OWHomologs(widget.OWWidget):
 
                 out_table = table if len(table) > 0 else None
 
-            self.info.set_output_summary(f"{len(out_table) if out_table else 0}")
-
             self.Outputs.genes.send(out_table)
         else:
             self.Outputs.genes.send(None)
-
-    def closeEvent(self, event):
-        super().closeEvent(event)
 
     def sizeHint(self):
         return super().sizeHint().expandedTo(QSize(200, 200))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When input has unknown entrez id (e.g. GDS909) widget raises an error:
```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/devel/orange3-bioinformatics/orangecontrib/bioinformatics/widgets/OWHomologs.py", line 165, in target_organism_change
    self.commit()
    ~~~~~~~~~~~^^
  File "/Users/aleserjavec/devel/orange-widget-base/orangewidget/gui.py", line 2003, in conditional_commit
    do_commit()
    ~~~~~~~~~^^
  File "/Users/aleserjavec/devel/orange-widget-base/orangewidget/gui.py", line 2013, in do_commit
    commit()
    ~~~~~~^^
  File "/Users/aleserjavec/devel/orange3-bioinformatics/orangecontrib/bioinformatics/widgets/OWHomologs.py", line 203, in commit
    homologs = self.find_homologs(genes)
  File "/Users/aleserjavec/devel/orange3-bioinformatics/orangecontrib/bioinformatics/widgets/OWHomologs.py", line 155, in find_homologs
    homologs = [g.homolog_gene(taxonomy_id=self.target_tax) for g in gm.genes]
                ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/devel/orange3-bioinformatics/orangecontrib/bioinformatics/ncbi/gene/__init__.py", line 74, in homolog_gene
    return self.homologs.get(taxonomy_id, None)
           ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
-------------------------------------------------------------------------------
```

##### Description of changes

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
